### PR TITLE
use Chef's embedded Ruby instead of system Ruby

### DIFF
--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,7 +1,7 @@
 module Xcode
   module Helper
     def xcversion_command
-      '/usr/local/bin/xcversion'.freeze
+      '/opt/chef/embedded/bin/xcversion'.freeze
     end
 
     def xcode_already_installed?(semantic_version)

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -8,7 +8,7 @@ property :path, String, default: '/Applications/Xcode.app'
 property :ios_simulators, Array
 
 action :setup do
-  gem_package 'xcode-install' do
+  chef_gem 'xcode-install' do
     options('--no-document')
   end
 end


### PR DESCRIPTION
The native Sierra Ruby can no longer install xcode-install due to jwt requirement of >= ruby 2.1, so we install to Chef's ruby. Fixes #4. 

