### PR TITLE
remove license acceptance in Xcode resource 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description 'Resources for configuring and provisioning macOS'
 chef_version '~> 13.0' if respond_to?(:chef_version)
-version '0.8.3'
+version '0.9.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -31,10 +31,6 @@ action :install_xcode do
     command "#{xcversion_command} install '#{xcversion_version(new_resource.version)}'"
     not_if { xcode_already_installed?(new_resource.version) }
   end
-
-  execute 'accept license' do
-    command '/usr/bin/xcodebuild -license accept'
-  end
 end
 
 action :install_simulators do


### PR DESCRIPTION
This should be done by recipes implementing this resource. This behavior can lead to later converges failing if the downstream recipe renames the Xcode application.