### PR TITLE
Update Xcode helpers to match namespace standard

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ default['macos']['mono']['package'] = 'MonoFramework-MDK-4.4.2.11.macos10.xamari
 default['macos']['mono']['version'] = '4.4.2'
 default['macos']['mono']['checksum'] = 'd8bfbee7ae4d0d1facaf0ddfb70c0de4b1a3d94bb1b4c38e8fa4884539f54e23'
 
-default['macos']['xcode']['version'] = '9.0'
+default['macos']['xcode']['version'] = '9.1'
 default['macos']['xcode']['simulator']['major_version'] = %w(11 10)
 
 default['macos']['network_time_server'] = 'time.windows.com'

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,5 +1,5 @@
 module Xcode
-  module Helper
+  module Helpers
     def xcversion_command
       '/opt/chef/embedded/bin/xcversion'.freeze
     end
@@ -54,3 +54,6 @@ module Xcode
     end
   end
 end
+
+Chef::Recipe.include(Xcode::Helpers)
+Chef::Resource.include(Xcode::Helpers)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,47 +1,49 @@
 include Chef::Mixin::ShellOut
 
-module Xcode
-  class << self
-    def installed?(semantic_version)
-      xcversion_output = shell_out("#{XCVersion.command} installed").stdout.split
-      installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
-      installed_xcodes.include?(semantic_version)
-    end
+module MacOS
+  module Xcode
+    class << self
+      def installed?(semantic_version)
+        xcversion_output = shell_out("#{XCVersion.command} installed").stdout.split
+        installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
+        installed_xcodes.include?(semantic_version)
+      end
 
-    def bundle_version_correct?
-      xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
-      node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
-    end
+      def bundle_version_correct?
+        xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
+        node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
+      end
 
-    module Simulator
-      class << self
-        def installed?(semantic_version)
-          available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
-        end
-
-        def highest_semantic_version(major_version, simulators)
-          requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
-          highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
-          if highest.nil?
-            Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
-          else
-            highest.join(' ')
+      module Simulator
+        class << self
+          def installed?(semantic_version)
+            available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
           end
-        end
 
-        def included_major_version
-          version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
-          sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
-          included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
-          included_simulator[:version].split('.').first.to_i
-        end
+          def highest_semantic_version(major_version, simulators)
+            requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
+            highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
+            if highest.nil?
+              Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
+            else
+              highest.join(' ')
+            end
+          end
 
-        def list
-          available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
-        end
+          def included_major_version
+            version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
+            sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
+            included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
+            included_simulator[:version].split('.').first.to_i
+          end
 
-        def available_versions
-          shell_out!("#{XCVersion.command} simulators").stdout
+          def list
+            available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
+          end
+
+          def available_versions
+            shell_out!("#{XCVersion.command} simulators").stdout
+          end
         end
       end
     end

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,71 +1,52 @@
 include Chef::Mixin::ShellOut
 
-module MacOS
-  module XCVersion
-    class << self
-      def command
-        '/opt/chef/embedded/bin/xcversion'.freeze
-      end
-
-      def version(semantic_version)
-        split_version = semantic_version.split('.')
-        if split_version.length == 2 && split_version.last == '0'
-          split_version.first
-        else
-          semantic_version
-        end
-      end
+module Xcode
+  class << self
+    def installed?(semantic_version)
+      xcversion_output = shell_out("#{XCVersion.command} installed").stdout.split
+      installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
+      installed_xcodes.include?(semantic_version)
     end
-  end
 
-  module Xcode
-    class << self
-      def installed?(semantic_version)
-        xcversion_output = shell_out("#{XCVersion.command} installed").stdout.split
-        installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
-        installed_xcodes.include?(semantic_version)
-      end
+    def bundle_version_correct?
+      xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
+      node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
+    end
 
-      def bundle_version_correct?
-        xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
-        node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
-      end
+    module Simulator
+      class << self
+        def installed?(semantic_version)
+          available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
+        end
 
-      module Simulator
-        class << self
-          def installed?(semantic_version)
-            available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
+        def highest_semantic_version(major_version, simulators)
+          requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
+          highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
+          if highest.nil?
+            Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
+          else
+            highest.join(' ')
           end
+        end
 
-          def highest_semantic_version(major_version, simulators)
-            requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
-            highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
-            if highest.nil?
-              Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
-            else
-              highest.join(' ')
-            end
-          end
+        def included_major_version
+          version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
+          sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
+          included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
+          included_simulator[:version].split('.').first.to_i
+        end
 
-          def included_major_version
-            version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
-            sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
-            included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
-            included_simulator[:version].split('.').first.to_i
-          end
+        def list
+          available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
+        end
 
-          def list
-            available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
-          end
-
-          def available_versions
-            shell_out!("#{XCVersion.command} simulators").stdout
-          end
+        def available_versions
+          shell_out!("#{XCVersion.command} simulators").stdout
         end
       end
     end
   end
 end
 
-Chef::Recipe.include(MacOS)
-Chef::Resource.include(MacOS)
+Chef::Recipe.include(MacOS::Xcode)
+Chef::Resource.include(MacOS::Xcode)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -13,42 +13,42 @@ module MacOS
         xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
         node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
       end
+    end
 
-      module Simulator
-        class << self
-          def installed?(semantic_version)
-            available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
-          end
+    module Simulator
+      class << self
+        def installed?(semantic_version)
+          available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
+        end
 
-          def highest_semantic_version(major_version, simulators)
-            requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
-            highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
-            if highest.nil?
-              Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
-            else
-              highest.join(' ')
-            end
+        def highest_semantic_version(major_version, simulators)
+          requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
+          highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
+          if highest.nil?
+            Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
+          else
+            highest.join(' ')
           end
+        end
 
-          def included_major_version
-            version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
-            sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
-            included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
-            included_simulator[:version].split('.').first.to_i
-          end
+        def included_major_version
+          version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
+          sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
+          included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
+          included_simulator[:version].split('.').first.to_i
+        end
 
-          def list
-            available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
-          end
+        def list
+          available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
+        end
 
-          def available_versions
-            shell_out!("#{XCVersion.command} simulators").stdout
-          end
+        def available_versions
+          shell_out!("#{XCVersion.command} simulators").stdout
         end
       end
     end
   end
 end
 
-Chef::Recipe.include(MacOS::Xcode)
-Chef::Resource.include(MacOS::Xcode)
+Chef::Recipe.include(MacOS)
+Chef::Resource.include(MacOS)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,5 +1,5 @@
-module Xcode
-  module Helpers
+module MacOS
+  module XcodeHelpers
     def xcversion_command
       '/opt/chef/embedded/bin/xcversion'.freeze
     end
@@ -55,5 +55,5 @@ module Xcode
   end
 end
 
-Chef::Recipe.include(Xcode::Helpers)
-Chef::Resource.include(Xcode::Helpers)
+Chef::Recipe.include(MacOS::XcodeHelpers)
+Chef::Resource.include(MacOS::XcodeHelpers)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -18,7 +18,7 @@ module MacOS
     module Simulator
       class << self
         def installed?(semantic_version)
-          available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
+          available_versions.include?("#{semantic_version} Simulator (installed)")
         end
 
         def highest_semantic_version(major_version, simulators)
@@ -39,7 +39,7 @@ module MacOS
         end
 
         def list
-          available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
+          available_versions.split(/\n/).map { |version| version.split[0...2] }
         end
 
         def available_versions

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,59 +1,71 @@
+include Chef::Mixin::ShellOut
+
 module MacOS
-  module XcodeHelpers
-    def xcversion_command
-      '/opt/chef/embedded/bin/xcversion'.freeze
-    end
+  module XCVersion
+    class << self
+      def command
+        '/opt/chef/embedded/bin/xcversion'.freeze
+      end
 
-    def xcode_already_installed?(semantic_version)
-      xcversion_output = shell_out("#{xcversion_command} installed").stdout.split
-      installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
-      installed_xcodes.include?(semantic_version)
-    end
-
-    def xcversion_version(semantic_version)
-      split_version = semantic_version.split('.')
-      if split_version.length == 2 && split_version.last == '0'
-        split_version.first
-      else
-        semantic_version
+      def version(semantic_version)
+        split_version = semantic_version.split('.')
+        if split_version.length == 2 && split_version.last == '0'
+          split_version.first
+        else
+          semantic_version
+        end
       end
     end
+  end
 
-    def requested_xcode_not_at_path
-      xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
-      node['macos']['xcode']['version'] != shell_out("defaults read #{xcode_version}").stdout.strip
-    end
-
-    def simulator_already_installed?(semantic_version)
-      available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
-    end
-
-    def highest_semantic_simulator_version(major_version, simulators)
-      requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
-      highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
-      if highest.nil?
-        Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
-      else
-        highest.join(' ')
+  module Xcode
+    class << self
+      def installed?(semantic_version)
+        xcversion_output = shell_out("#{XCVersion.command} installed").stdout.split
+        installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
+        installed_xcodes.include?(semantic_version)
       end
-    end
 
-    def included_simulator_major_version
-      version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
-      sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
-      included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
-      included_simulator[:version].split('.').first.to_i
-    end
+      def bundle_version_correct?
+        xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
+        node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
+      end
 
-    def simulator_list
-      available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
-    end
+      module Simulator
+        class << self
+          def installed?(semantic_version)
+            available_simulator_versions.include?("#{semantic_version} Simulator (installed)")
+          end
 
-    def available_simulator_versions
-      shell_out!("#{xcversion_command} simulators").stdout
+          def highest_semantic_version(major_version, simulators)
+            requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
+            highest = simulators.select { |name, vers| requirement.match?(name, vers) }.max
+            if highest.nil?
+              Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
+            else
+              highest.join(' ')
+            end
+          end
+
+          def included_major_version
+            version_matcher    = /\d{1,2}\.\d{0,2}\.?\d{0,3}/
+            sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
+            included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
+            included_simulator[:version].split('.').first.to_i
+          end
+
+          def list
+            available_simulator_versions.split(/\n/).map { |version| version.split[0...2] }
+          end
+
+          def available_versions
+            shell_out!("#{XCVersion.command} simulators").stdout
+          end
+        end
+      end
     end
   end
 end
 
-Chef::Recipe.include(MacOS::XcodeHelpers)
-Chef::Resource.include(MacOS::XcodeHelpers)
+Chef::Recipe.include(MacOS)
+Chef::Resource.include(MacOS)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -17,5 +17,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS::XCVersion)
-Chef::Resource.include(MacOS::XCVersion)
+Chef::Recipe.include(MacOS)
+Chef::Resource.include(MacOS)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -1,0 +1,21 @@
+module MacOS
+  module XCVersion
+    class << self
+      def command
+        '/opt/chef/embedded/bin/xcversion'.freeze
+      end
+
+      def version(semantic_version)
+        split_version = semantic_version.split('.')
+        if split_version.length == 2 && split_version.last == '0'
+          split_version.first
+        else
+          semantic_version
+        end
+      end
+    end
+  end
+end
+
+Chef::Recipe.include(MacOS::XCVersion)
+Chef::Resource.include(MacOS::XCVersion)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description 'Resources for configuring and provisioning macOS'
 chef_version '~> 13.0' if respond_to?(:chef_version)
-version '0.10.0'
+version '0.10.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description 'Resources for configuring and provisioning macOS'
 chef_version '~> 13.0' if respond_to?(:chef_version)
-version '0.10.1'
+version '0.12.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -1,5 +1,3 @@
-include Xcode::Helper
-
 resource_name :xcode
 default_action %i(setup install_xcode install_simulators)
 

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -21,26 +21,26 @@ action :install_xcode do
 
   execute 'update available Xcode versions' do
     environment DEVELOPER_CREDENTIALS
-    command "#{xcversion_command} update"
+    command "#{XCVersion.command} update"
   end
 
   execute "install Xcode #{new_resource.version}" do
     environment DEVELOPER_CREDENTIALS
-    command "#{xcversion_command} install '#{xcversion_version(new_resource.version)}'"
-    not_if { xcode_already_installed?(new_resource.version) }
+    command "#{XCVersion.command} install '#{XCVersion.version(new_resource.version)}'"
+    not_if { Xcode.installed?(new_resource.version) }
   end
 end
 
 action :install_simulators do
   if new_resource.ios_simulators
     new_resource.ios_simulators.each do |major_version|
-      next if major_version.to_i >= included_simulator_major_version
-      version = highest_semantic_simulator_version(major_version, simulator_list)
+      next if major_version.to_i >= Xcode::Simulator.included_major_version
+      version = Xcode::Simulator.highest_semantic_version(major_version, Xcode::Simulator.list)
 
       execute "install latest iOS #{major_version} Simulator" do
         environment DEVELOPER_CREDENTIALS
-        command "#{xcversion_command} simulators --install='#{version}'"
-        not_if { simulator_already_installed?(version) }
+        command "#{XCVersion.command} simulators --install='#{version}'"
+        not_if { Xcode::Simulator.installed?(version) }
       end
     end
   end

--- a/test/cookbooks/macos_test/.kitchen.yml
+++ b/test/cookbooks/macos_test/.kitchen.yml
@@ -26,3 +26,12 @@ suites:
     verifier:
       inspec_tests:
         - test/smoke/default
+
+  - name: xcode
+    run_list:
+      - recipe[macos::xcode]
+    excludes:
+      - apex/macos-10.11.6
+    verifier:
+      inspec_tests:
+        - test/smoke/xcode

--- a/test/cookbooks/macos_test/test/smoke/xcode/xcode_test.rb
+++ b/test/cookbooks/macos_test/test/smoke/xcode/xcode_test.rb
@@ -10,7 +10,7 @@ control 'xcode' do
     it { should exist }
   end
 
-  describe command('/usr/local/bin/xcversion simulators') do
+  describe command('/opt/chef/embedded/bin/xcversion simulators') do
     its('stdout') { should match(/iOS 10\.3\.1 Simulator \(installed\)/) }
   end
 end

--- a/test/cookbooks/macos_test/test/smoke/xcode/xcode_test.rb
+++ b/test/cookbooks/macos_test/test/smoke/xcode/xcode_test.rb
@@ -1,16 +1,16 @@
 control 'xcode' do
   desc 'application Xcode exists and Developer mode is enabled'
 
-  describe file('/Applications/Xcode.app'), :skip do
+  describe file('/Applications/Xcode.app') do
     it { should exist }
     it { should be_symlink }
   end
 
-  describe directory('/Applications/Xcode-9.app'), :skip do
+  describe directory('/Applications/Xcode-9.1.app') do
     it { should exist }
   end
 
-  describe command('/usr/local/bin/xcversion simulators'), :skip do
+  describe command('/usr/local/bin/xcversion simulators') do
     its('stdout') { should match(/iOS 10\.3\.1 Simulator \(installed\)/) }
   end
 end


### PR DESCRIPTION
This PR updates the name of the Xcode helper module and also automatically includes it in all recipes and resources. 

I've also updated the Xcode test cookbook to run a suite specific to testing Xcode installs, and updated the default Xcode version node attribute to Xcode 9.1. 