### PR TITLE
Hotfix/simulators not found

### DIFF
--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -4,7 +4,7 @@ module MacOS
   module Xcode
     class << self
       def installed?(semantic_version)
-        xcversion_output = shell_out(XCVersion.installed).stdout.split
+        xcversion_output = shell_out(XCVersion.installed_xcodes).stdout.split
         installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
         installed_xcodes.include?(semantic_version)
       end

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -31,11 +31,11 @@ module MacOS
       end
 
       def available_versions
-        shell_out!("#{XCVersion.command} simulators").stdout
+        shell_out!(XCVersion.list_simulators).stdout
       end
 
       def available_list
-        available_versions.split(/\n/).map { |version| version.split[0...2] }
+        available_versions.split(/\n/).map { |version| version.split[0..1] }
       end
 
       def latest_semantic_version(major_version)
@@ -45,7 +45,8 @@ module MacOS
 
       class << self
         def installed?(semantic_version)
-          shell_out!("#{XCVersion.command} simulators").stdout.include?("#{semantic_version} Simulator (installed)")
+          shell_out!(XCVersion.list_simulators)
+            .stdout.include?("#{semantic_version} Simulator (installed)")
         end
 
         def included_major_version

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -4,7 +4,7 @@ module MacOS
   module Xcode
     class << self
       def installed?(semantic_version)
-        xcversion_output = shell_out("#{XCVersion.command} installed").stdout.split
+        xcversion_output = shell_out(XCVersion.installed).stdout.split
         installed_xcodes = xcversion_output.values_at(*xcversion_output.each_index.select(&:even?))
         installed_xcodes.include?(semantic_version)
       end

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -15,26 +15,37 @@ module MacOS
       end
     end
 
-    module Simulator
+    class Simulator
+      attr_reader :version
+
+      def initialize(major_version)
+        while available_list.empty?
+          Chef::Log.warn('iOS Simulator list not populated yet')
+          sleep 10
+        end
+        if latest_semantic_version(major_version).nil?
+          Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
+        else
+          @version = latest_semantic_version(major_version).join(' ')
+        end
+      end
+
+      def available_versions
+        shell_out!("#{XCVersion.command} simulators").stdout
+      end
+
+      def available_list
+        available_versions.split(/\n/).map { |version| version.split[0...2] }
+      end
+
+      def latest_semantic_version(major_version)
+        requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
+        available_list.select { |platform, version| requirement.match?(platform, version) }.max
+      end
+
       class << self
         def installed?(semantic_version)
-          available_versions.include?("#{semantic_version} Simulator (installed)")
-        end
-
-        def highest_semantic_version(major_version)
-          requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
-          if available_list.empty?
-            Chef::Log.error('iOS simulator list not populated yet, refreshing...')
-            shell_out('sleep 20')
-            highest_semantic_version(major_version)
-          else
-            highest = available_list.select { |name, vers| requirement.match?(name, vers) }.max
-            if highest.nil?
-              Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
-            else
-              highest.join(' ')
-            end
-          end
+          shell_out!("#{XCVersion.command} simulators").stdout.include?("#{semantic_version} Simulator (installed)")
         end
 
         def included_major_version
@@ -42,14 +53,6 @@ module MacOS
           sdks               = shell_out!('/usr/bin/xcodebuild -showsdks').stdout
           included_simulator = sdks.match(/Simulator - iOS (?<version>#{version_matcher})/)
           included_simulator[:version].split('.').first.to_i
-        end
-
-        def available_list
-          available_versions.split(/\n/).map { |version| version.split[0...2] }
-        end
-
-        def available_versions
-          shell_out!("#{XCVersion.command} simulators").stdout
         end
       end
     end

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -23,11 +23,17 @@ module MacOS
 
         def highest_semantic_version(major_version)
           requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
-          highest = available_list.select { |name, vers| requirement.match?(name, vers) }.max
-          if highest.nil?
-            Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
+          if available_list.empty?
+            Chef::Log.error('iOS simulator list not populated yet, refreshing...')
+            shell_out('sleep 20')
+            highest_semantic_version(major_version)
           else
-            highest.join(' ')
+            highest = available_list.select { |name, vers| requirement.match?(name, vers) }.max
+            if highest.nil?
+              Chef::Application.fatal!("iOS #{major_version} Simulator no longer available from Apple!")
+            else
+              highest.join(' ')
+            end
           end
         end
 

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -30,17 +30,17 @@ module MacOS
         end
       end
 
-      def available_versions
-        shell_out!(XCVersion.list_simulators).stdout
+      def latest_semantic_version(major_version)
+        requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
+        available_list.select { |platform, version| requirement.match?(platform, version) }.max
       end
 
       def available_list
         available_versions.split(/\n/).map { |version| version.split[0..1] }
       end
 
-      def latest_semantic_version(major_version)
-        requirement = Gem::Dependency.new('iOS', "~> #{major_version}")
-        available_list.select { |platform, version| requirement.match?(platform, version) }.max
+      def available_versions
+        shell_out!(XCVersion.list_simulators).stdout
       end
 
       class << self

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -1,28 +1,30 @@
 module MacOS
   module XCVersion
     class << self
-      def command
+      def xcversion
         '/opt/chef/embedded/bin/xcversion'.freeze
       end
 
       def update
-        command + ' update'
+        xcversion + ' update'
       end
 
       def list_simulators
-        command + ' simulators'
+        xcversion + ' simulators'
       end
 
       def install_simulator(version)
-        command + " simulators --install='#{version}'"
+        xcversion + " simulators --install='#{version}'"
       end
 
       def list_xcodes
-        command + ' list'
+        xcversion + ' list'
       end
 
       def install_xcode(version)
-        command + " install '#{apple_pseudosemantic_version(version)}'"
+        xcversion + " install '#{apple_pseudosemantic_version(version)}'"
+      end
+
       def installed_xcodes
         xcversion + ' installed'
       end

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -9,8 +9,16 @@ module MacOS
         command + ' update'
       end
 
+      def list_simulators
+        command + ' simulators'
+      end
+
       def install_simulator(version)
         command + " simulators --install='#{version}'"
+      end
+
+      def list_xcodes
+        command + ' list'
       end
 
       def install_xcode(version)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -2,31 +2,31 @@ module MacOS
   module XCVersion
     class << self
       def xcversion
-        '/opt/chef/embedded/bin/xcversion'.freeze
+        '/opt/chef/embedded/bin/xcversion '.freeze
       end
 
       def update
-        xcversion + ' update'
+        xcversion + 'update'
       end
 
       def list_simulators
-        xcversion + ' simulators'
+        xcversion + 'simulators'
       end
 
       def install_simulator(version)
-        xcversion + " simulators --install='#{version}'"
+        xcversion + "simulators --install='#{version}'"
       end
 
       def list_xcodes
-        xcversion + ' list'
+        xcversion + 'list'
       end
 
       def install_xcode(version)
-        xcversion + " install '#{apple_pseudosemantic_version(version)}'"
+        xcversion + "install '#{apple_pseudosemantic_version(version)}'"
       end
 
       def installed_xcodes
-        xcversion + ' installed'
+        xcversion + 'installed'
       end
 
       def apple_pseudosemantic_version(semantic_version)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -23,6 +23,8 @@ module MacOS
 
       def install_xcode(version)
         command + " install '#{apple_pseudosemantic_version(version)}'"
+      def installed_xcodes
+        xcversion + ' installed'
       end
 
       def apple_pseudosemantic_version(semantic_version)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -5,7 +5,19 @@ module MacOS
         '/opt/chef/embedded/bin/xcversion'.freeze
       end
 
-      def version(semantic_version)
+      def update
+        command + ' update'
+      end
+
+      def install_simulator(version)
+        command + " simulators --install='#{version}'"
+      end
+
+      def install_xcode(version)
+        command + " install '#{apple_pseudosemantic_version(version)}'"
+      end
+
+      def apple_pseudosemantic_version(semantic_version)
         split_version = semantic_version.split('.')
         if split_version.length == 2 && split_version.last == '0'
           split_version.first

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -19,14 +19,14 @@ action :setup do
 
   execute 'update available Xcode versions' do
     environment DEVELOPER_CREDENTIALS
-    command XCVersion.command.update
+    command XCVersion.update
   end
 end
 
 action :install_xcode do
   execute "install Xcode #{new_resource.version}" do
     environment DEVELOPER_CREDENTIALS
-    command XCVersion.command.install_xcode
+    command XCVersion.install_xcode
     not_if { Xcode.installed?(new_resource.version) }
   end
 end

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -36,7 +36,7 @@ action :install_simulators do
     new_resource.ios_simulators.each do |major_version|
       next if major_version.to_i >= Xcode::Simulator.included_major_version
       version = Xcode::Simulator.highest_semantic_version(major_version)
-      
+
       execute "install latest iOS #{major_version} Simulator" do
         environment DEVELOPER_CREDENTIALS
         command "#{XCVersion.command} simulators --install='#{version}'"

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -26,7 +26,7 @@ end
 action :install_xcode do
   execute "install Xcode #{new_resource.version}" do
     environment DEVELOPER_CREDENTIALS
-    command XCVersion.install_xcode
+    command XCVersion.install_xcode(new_resource.version)
     not_if { Xcode.installed?(new_resource.version) }
   end
 end

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -36,6 +36,7 @@ action :install_simulators do
     new_resource.ios_simulators.each do |major_version|
       next if major_version.to_i >= Xcode::Simulator.included_major_version
       version = Xcode::Simulator.highest_semantic_version(major_version)
+      
       execute "install latest iOS #{major_version} Simulator" do
         environment DEVELOPER_CREDENTIALS
         command "#{XCVersion.command} simulators --install='#{version}'"

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -35,11 +35,9 @@ action :install_simulators do
   if new_resource.ios_simulators
     new_resource.ios_simulators.each do |major_version|
       next if major_version.to_i >= Xcode::Simulator.included_major_version
-      version = Xcode::Simulator.highest_semantic_version(major_version)
-
       execute "install latest iOS #{major_version} Simulator" do
         environment DEVELOPER_CREDENTIALS
-        command "#{XCVersion.command} simulators --install='#{version}'"
+        command lazy { "#{XCVersion.command} simulators --install='#{Xcode::Simulator.highest_semantic_version(major_version)}'" }
         not_if { Xcode::Simulator.installed?(version) }
       end
     end

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -35,9 +35,10 @@ action :install_simulators do
   if new_resource.ios_simulators
     new_resource.ios_simulators.each do |major_version|
       next if major_version.to_i >= Xcode::Simulator.included_major_version
+      version = Xcode::Simulator.highest_semantic_version(major_version)
       execute "install latest iOS #{major_version} Simulator" do
         environment DEVELOPER_CREDENTIALS
-        command lazy { "#{XCVersion.command} simulators --install='#{Xcode::Simulator.highest_semantic_version(major_version)}'" }
+        command "#{XCVersion.command} simulators --install='#{version}'"
         not_if { Xcode::Simulator.installed?(version) }
       end
     end

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -35,7 +35,7 @@ action :install_simulators do
   if new_resource.ios_simulators
     new_resource.ios_simulators.each do |major_version|
       next if major_version.to_i >= Xcode::Simulator.included_major_version
-      version = Xcode::Simulator.highest_semantic_version(major_version)
+      version = Xcode::Simulator.new(major_version).version
 
       execute "install latest iOS #{major_version} Simulator" do
         environment DEVELOPER_CREDENTIALS

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -19,14 +19,14 @@ action :setup do
 
   execute 'update available Xcode versions' do
     environment DEVELOPER_CREDENTIALS
-    command "#{XCVersion.command} update"
+    command XCVersion.command.update
   end
 end
 
 action :install_xcode do
   execute "install Xcode #{new_resource.version}" do
     environment DEVELOPER_CREDENTIALS
-    command "#{XCVersion.command} install '#{XCVersion.version(new_resource.version)}'"
+    command XCVersion.command.install_xcode
     not_if { Xcode.installed?(new_resource.version) }
   end
 end
@@ -39,7 +39,7 @@ action :install_simulators do
 
       execute "install latest iOS #{major_version} Simulator" do
         environment DEVELOPER_CREDENTIALS
-        command "#{XCVersion.command} simulators --install='#{version}'"
+        command XCVersion.install_simulator(version)
         not_if { Xcode::Simulator.installed?(version) }
       end
     end

--- a/test/cookbooks/macos_test/.kitchen.yml
+++ b/test/cookbooks/macos_test/.kitchen.yml
@@ -2,9 +2,6 @@
 driver:
   name: vagrant
   provider: parallels
-  customize:
-    memory: 10240
-    cpus: 8
 
 provisioner:
   name: chef_zero

--- a/test/cookbooks/macos_test/recipes/xcode.rb
+++ b/test/cookbooks/macos_test/recipes/xcode.rb
@@ -4,12 +4,12 @@ if node['platform_version'].match?(/10\.13/) || node['platform_version'].match?(
   end
 
   xcode '9.2' do
-    ios_simulators %w(11 10)
+    ios_simulators lazy { %w(11 10) }
   end
 
 elsif node['platform_version'].match?(/10\.11/)
 
   xcode '8.2.1' do
-    ios_simulators %w(10 9)
+    ios_simulators lazy { %w(10 9) }
   end
 end

--- a/test/cookbooks/macos_test/recipes/xcode.rb
+++ b/test/cookbooks/macos_test/recipes/xcode.rb
@@ -4,12 +4,12 @@ if node['platform_version'].match?(/10\.13/) || node['platform_version'].match?(
   end
 
   xcode '9.2' do
-    ios_simulators lazy { %w(11 10) }
+    ios_simulators %w(11 10)
   end
 
 elsif node['platform_version'].match?(/10\.11/)
 
   xcode '8.2.1' do
-    ios_simulators lazy { %w(10 9) }
+    ios_simulators %w(10 9)
   end
 end


### PR DESCRIPTION
This PR fixes an issue with iOS simulator installation in 10.11 and 10.13, where the xcode-install gem does not populate the simulator list immediately after wrapping up an Xcode install.

The method called by the `install_simulators` action will refresh the gem's simulator list output until at least one simulator is scraped from Apple. 