### PR TITLE
Fix failing disable software updates smoke tests on 10.11

### DIFF
--- a/recipes/disable_software_updates.rb
+++ b/recipes/disable_software_updates.rb
@@ -1,11 +1,11 @@
-plist 'disable automatic software update check' do
-  path '/Library/Preferences/com.apple.SoftwareUpdate.plist'
-  entry 'AutomaticCheckEnabled'
-  value false
-end
-
 plist 'disable automatic software update downloads' do
   path '/Library/Preferences/com.apple.SoftwareUpdate.plist'
   entry 'AutomaticDownload'
+  value false
+end
+
+plist 'disable automatic software update check' do
+  path '/Library/Preferences/com.apple.SoftwareUpdate.plist'
+  entry 'AutomaticCheckEnabled'
   value false
 end


### PR DESCRIPTION
This PR resolves an issue where disabling AutomaticCheckEnabled before disabling AutomaticDownload in the SoftwareUpdate plist on El Capitan prevents the AutomaticDownload from writing a value. 

As long as AutomaticCheckEnabled is false, AutomaticDownloads are also prevented, so the behavior on El Capitan is still technically prevented without this change. 