### PR TITLE
Name resource fc108

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description 'Resources for configuring and provisioning macOS'
 chef_version '~> 13.0' if respond_to?(:chef_version)
-version '0.12.1'
+version '0.12.2'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/machine_name.rb
+++ b/resources/machine_name.rb
@@ -1,24 +1,24 @@
-resource_name :device_name
+resource_name :machine_name
 default_action :run
 
 BASE_COMMAND = '/usr/sbin/scutil'.freeze
 SMB_SERVER_PLIST = '/Library/Preferences/SystemConfiguration/com.apple.smb.server'.freeze
 
-property :device_name, String, name_property: true
+property :machine_name, String, name_property: true
 
 # We cannot set the LocalHostName here because it does not conform to
 # the DNS standards outlined in RFC 1034 (section 3.5)
 
 action :run do
   execute BASE_COMMAND do
-    command "#{BASE_COMMAND} --set HostName '#{new_resource.device_name}'"
+    command "#{BASE_COMMAND} --set HostName '#{new_resource.machine_name}'"
   end
 
   execute BASE_COMMAND do
-    command "#{BASE_COMMAND} --set ComputerName '#{new_resource.device_name}'"
+    command "#{BASE_COMMAND} --set ComputerName '#{new_resource.machine_name}'"
   end
 
   defaults SMB_SERVER_PLIST do
-    settings 'NetBIOSName' => new_resource.device_name
+    settings 'NetBIOSName' => new_resource.machine_name
   end
 end

--- a/resources/name.rb
+++ b/resources/name.rb
@@ -1,24 +1,24 @@
-resource_name :name
+resource_name :device_name
 default_action :run
 
 BASE_COMMAND = '/usr/sbin/scutil'.freeze
 SMB_SERVER_PLIST = '/Library/Preferences/SystemConfiguration/com.apple.smb.server'.freeze
 
-property :name, String, name_property: true
+property :device_name, String, name_property: true
 
 # We cannot set the LocalHostName here because it does not conform to
 # the DNS standards outlined in RFC 1034 (section 3.5)
 
 action :run do
   execute BASE_COMMAND do
-    command "#{BASE_COMMAND} --set HostName '#{new_resource.name}'"
+    command "#{BASE_COMMAND} --set HostName '#{new_resource.device_name}'"
   end
 
   execute BASE_COMMAND do
-    command "#{BASE_COMMAND} --set ComputerName '#{new_resource.name}'"
+    command "#{BASE_COMMAND} --set ComputerName '#{new_resource.device_name}'"
   end
 
   defaults SMB_SERVER_PLIST do
-    settings 'NetBIOSName' => new_resource.name
+    settings 'NetBIOSName' => new_resource.device_name
   end
 end

--- a/test/cookbooks/macos_test/.kitchen.yml
+++ b/test/cookbooks/macos_test/.kitchen.yml
@@ -23,6 +23,7 @@ suites:
       - recipe[macos::disable_software_updates]
       - recipe[macos_test::new_users]
       - recipe[macos_test::preferences]
+      - recipe[macos_test::machine_name]
     verifier:
       inspec_tests:
         - test/smoke/default

--- a/test/cookbooks/macos_test/metadata.rb
+++ b/test/cookbooks/macos_test/metadata.rb
@@ -1,4 +1,4 @@
 name 'macos_test'
-version '1.0.0'
+version '1.0.1'
 
 depends 'macos'

--- a/test/cookbooks/macos_test/recipes/machine_name.rb
+++ b/test/cookbooks/macos_test/recipes/machine_name.rb
@@ -1,0 +1,1 @@
+machine_name "New#{node['platform_version']}_Washing_Machine"

--- a/test/cookbooks/macos_test/test/smoke/default/machine_name_test.rb
+++ b/test/cookbooks/macos_test/test/smoke/default/machine_name_test.rb
@@ -1,0 +1,16 @@
+control 'machine name' do
+  desc 'machine name is set to the format "New#{macos_semantic_version}_Washing_Machine"'
+
+  macos_semantic_version = command('sw_vers -productVersion').stdout.strip
+  hostname_pattern = /New#{macos_semantic_version}_Washing_Machine/
+
+  hostname_commands = ['hostname',
+                       'scutil --get ComputerName',
+                       'scutil --get HostName']
+
+  hostname_commands.each do |hostname_command|
+    describe command(hostname_command) do
+      its('stdout') { should match hostname_pattern }
+    end
+  end
+end


### PR DESCRIPTION
[Bug 2042302 - FC108: Resource should not define a property named 'name': ./resources/name.rb:7](https://office.visualstudio.com/APEX/_workitems?id=2042302&src=alerts&src-action=summary_id_link&fullScreen=true&tracking_data=eyJTb3VyY2UiOiJFbWFpbCIsIlR5cGUiOiJOb3RpZmljYXRpb24iLCJTSUQiOiIyNDAzIiwiU1R5cGUiOiJHUlAiLCJSZWNpcCI6MSwiX3hjaSI6eyJOSUQiOjI0ODkyMjk4LCJNUmVjaXAiOiJtMD0xICIsIkFjdCI6ImMyZjBjNDc4LWViNWYtNGVlMy1hNDU5LTdjZjE5MmYwZTUwYiIsImZmIjoiQ0QifX0%3D&_a=edit)

- Renamed name to machine_name to be consistent with apex-automation-cookbook
- Add test recipe and smoke test
- Bump up version number