### PR TITLE
add sleep for El Capitan platform to avoid race condition

### DIFF
--- a/recipes/disable_software_updates.rb
+++ b/recipes/disable_software_updates.rb
@@ -4,6 +4,8 @@ plist 'disable automatic software update downloads' do
   value false
 end
 
+sleep 10 if node['platform_version'].match?(/10\.11/)
+
 plist 'disable automatic software update check' do
   path '/Library/Preferences/com.apple.SoftwareUpdate.plist'
   entry 'AutomaticCheckEnabled'


### PR DESCRIPTION
A race condition occurs when `disable_software_updates` is run with the `new_users` test recipe on 10.11. A second call to write to the SoftwareUpdate.plist is not processed until another converge happens, unless a delay is implemented between the two calls to the `plist` resource. 