### PR TITLE
swap build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ use-cases of the macOS cookbook's recources.
 
 |||
 |-|-|
-| macOS Sierra 10.12 | ![build-status-1012](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2143/badge) |
-| macOS High Sierra 10.13 | ![build-status-1013](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2140/badge) |
+| macOS High Sierra 10.13 | ![build-status-1013](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2143/badge) |
+| macOS Sierra 10.12 | ![build-status-1012](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2140/badge) |
 |||
 
 Requirements


### PR DESCRIPTION
Sierra and High Sierra build badges were swapped - noticed when I cancelled a 10.13 build and the 10.12 badge showed the status instead.