### PR TITLE
Kitchen fixes

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description 'Resources for configuring and provisioning macOS'
 chef_version '~> 13.0' if respond_to?(:chef_version)
-version '1.3.0'
+version '1.3.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/test/cookbooks/macos_test/.kitchen.yml
+++ b/test/cookbooks/macos_test/.kitchen.yml
@@ -6,8 +6,6 @@ driver:
 provisioner:
   name: chef_zero
   always_update_cookbooks: true
-  multiple_converge: 3
-  enforce_idempotency: true
   require_chef_omnibus: true
 
 verifier:
@@ -15,11 +13,15 @@ verifier:
   sudo: true
 
 platforms:
-  - name: apex/macos-10.12.6
   - name: apex/macos-10.13.3
+  - name: apex/macos-10.12.6
+  - name: apex/macos-10.11.6
+
 
 suites:
   - name: default
+    multiple_converge: 2
+    enforce_idempotency: true
     run_list:
       - recipe[macos::keep_awake]
       - recipe[macos_test::new_users]
@@ -41,6 +43,8 @@ suites:
         - test/smoke/xcode
 
   - name: spotlight
+    multiple_converge: 2
+    enforce_idempotency: true
     run_list:
       - recipe[macos_test::spotlight]
     verifier:


### PR DESCRIPTION
this PR updates the test cookbook kitchen to run the El Capitan test suite and disables multiple converges for the Xcode suite. 