### PR TITLE
Feature/useraddtogroup: macos_user new property "groups"

### DIFF
--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -6,6 +6,7 @@ property :password, String, default: 'password'
 property :autologin, [TrueClass]
 property :admin, [TrueClass]
 property :fullname, String
+property :groups, [Array, String]
 
 action_class do
   def user_home
@@ -74,6 +75,24 @@ action :create do
       owner 'root'
       group 'wheel'
       mode '0600'
+    end
+  end
+
+  if property_is_set?(:groups)
+    if groups.is_a? String
+      group groups do
+        action :create
+        members username
+        append true
+      end
+    else
+      groups.each do |g|
+        group g do
+          action :create
+          members username
+          append true
+        end
+      end
     end
   end
 end

--- a/test/cookbooks/macos_test/recipes/new_users.rb
+++ b/test/cookbooks/macos_test/recipes/new_users.rb
@@ -3,10 +3,17 @@ macos_user 'create admin user randall and enable automatic login' do
   password 'correct-horse-battery-staple'
   autologin true
   admin true
+  groups 'alpha'
 end
 
 macos_user 'create non-admin user johnny' do
   username 'johnny'
   fullname 'Johnny Appleseed'
+  password 'yang-yolked-cordon-karate'
+  groups %w(alpha beta)
+end
+
+macos_user 'create non-admin user paul' do
+  username 'paul'
   password 'yang-yolked-cordon-karate'
 end

--- a/test/cookbooks/macos_test/test/smoke/default/new_users_test.rb
+++ b/test/cookbooks/macos_test/test/smoke/default/new_users_test.rb
@@ -6,6 +6,7 @@ control 'new macOS users' do
     its('uid') { should eq 503 }
     its('gid') { should eq 20 }
     its('home') { should eq '/Users/randall' }
+    its('groups') { should include 'alpha' }
   end
 
   describe user('johnny') do
@@ -13,11 +14,20 @@ control 'new macOS users' do
     its('uid') { should eq 504 }
     its('gid') { should eq 20 }
     its('home') { should eq '/Users/johnny' }
+    its('groups') { should include 'alpha' }
+    its('groups') { should include 'beta' }
   end
 
   realname_cmd = 'dscl . read /Users/johnny RealName | grep -v RealName | cut -c 2-'
 
   describe command(realname_cmd) do
     its('stdout.strip') { should eq 'Johnny Appleseed' }
+  end
+
+  describe user('paul') do
+    it { should exist }
+    its('uid') { should eq 505 }
+    its('gid') { should eq 20 }
+    its('home') { should eq '/Users/paul' }
   end
 end


### PR DESCRIPTION
Add new property called "groups" to macos_user resource. This property will take either a single group in the form of a String or a list of groups in the form of an Array. 

#### Example
```
macos_user 'create new user Sam' do
    username 'sam'
    groups 'samsgroup'
end
```
#### Testing
- Add new macos_user "paul" not part of any group
- Add macos_user "randall" to the "beta" group
- Add macos_user "johnny" to the "alpha" and "beta" groups