### PR TITLE
Resolve build failure using correct InSpec syntax

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '~> 13.0' if respond_to?(:chef_version)
-version '1.8.0'
+version '1.8.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/test/smoke/default/new_users_test.rb
+++ b/test/smoke/default/new_users_test.rb
@@ -22,9 +22,9 @@ control 'new macOS users' do
     its('groups') { should_not include  'admin' }
   end
 
-  describe group('admin') do
+  describe groups.where { name == 'admin'} do
     it { should exist }
-    its('gid') { should eq 80 }
+    its('gids') { should include 80 }
   end
 
   realname_cmd = 'dscl . read /Users/johnny RealName | grep -v RealName | cut -c 2-'


### PR DESCRIPTION
There's a whitespace issue, but I'll take care of that in the next hotfix PR for `keep_awake` resources updated.