### PR TITLE
ensure xcode-install gem is in Chef embedded even if ChefDK is present

### DIFF
--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -7,7 +7,7 @@ property :ios_simulators, Array
 
 action :setup do
   chef_gem 'xcode-install' do
-    options('--no-document')
+    options('--no-document --no-user-install')
   end
 
   CREDENTIALS_DATA_BAG = data_bag_item(:credentials, :apple_id)


### PR DESCRIPTION
This PR ensures that the `xcode-install` gem binary is installed to `/opt/chef/embedded/` even if the ChefDK is installed, since it becomes the user's `chef gem` home. 

This resolves #68.