### PR TITLE
remove idempotency enforcement for keep awake

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,7 +33,7 @@ suites:
   - name: keep_awake
     provisioner:
       multiple_converge: 2
-      enforce_idempotency: true
+      enforce_idempotency: false
     run_list:
       - recipe[macos::keep_awake]
     verifier:


### PR DESCRIPTION
This hotfix removes the idempotency enforcement for the `keep_awake` suite. 