### PR TITLE
Install Command Line Tools as part of Xcode setup

### DIFF
--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -1,0 +1,20 @@
+include Chef::Mixin::ShellOut
+
+module MacOS
+  class CommandLineTools
+    attr_reader :product
+
+    def initialize
+      @product = available_products.lines
+                                   .select { |s| s.include?('* Command') }
+                                   .last.tr('*', '').strip
+    end
+
+    def available_products
+      shell_out('softwareupdate -l').stdout
+    end
+  end
+end
+
+Chef::Recipe.include(MacOS)
+Chef::Resource.include(MacOS)

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -17,7 +17,7 @@ module MacOS
     end
 
     def available_products
-      shell_out('softwareupdate -l').stdout
+      shell_out(['softwareupdate', '--list']).stdout
     end
   end
 end

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -5,9 +5,15 @@ module MacOS
     attr_reader :product
 
     def initialize
-      @product = available_products.lines
-                                   .select { |s| s.include?('* Command') }
-                                   .last.tr('*', '').strip
+      @product = if available_command_line_tools.empty?
+                   'none'
+                 else
+                   available_command_line_tools.last.tr('*', '').strip
+                 end
+    end
+
+    def available_command_line_tools
+      available_products.lines.select { |s| s.include?('* Command') }
     end
 
     def available_products

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -6,6 +6,18 @@ property :path, String, default: '/Applications/Xcode.app'
 property :ios_simulators, Array
 
 action :setup do
+  file 'sentinel to make CLT available' do
+    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+    not_if { ::File.exist?('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib') }
+    notifies :run, 'execute[install Xcode CLT]', :immediately
+  end
+
+  execute 'install Xcode CLT' do
+    command lazy { "softwareupdate --verbose -i '#{CommandLineTools.new}'" }
+    action :nothing
+    notifies :delete, 'file[sentinel to make CLT available]', :immediately
+  end
+
   chef_gem 'xcode-install' do
     options('--no-document --no-user-install')
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require_relative '../libraries/plist'
 require_relative '../libraries/systemsetup'
 require_relative '../libraries/xcode'
 require_relative '../libraries/xcversion'
+require_relative '../libraries/command_line_tools'
 require_relative '../libraries/security_cmd'
 
 RSpec.configure do |config|

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -5,7 +5,7 @@ describe MacOS::CommandLineTools do
   context 'when provided an available list of software update products' do
     before do
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_products)
-        .and_return(<<-SOFTWAREUPDATE_LIST
+        .and_return(<<~SOFTWAREUPDATE_LIST
                     Software Update Tool
                     Finding available software
                     Software Update found the following new or updated software:

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+include MacOS
+
+describe MacOS::CommandLineTools do
+  context 'when provided an available list of software update products' do
+    before do
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_products)
+        .and_return(<<-SOFTWAREUPDATE_LIST
+                    Software Update Tool
+                    Finding available software
+                    Software Update found the following new or updated software:
+                       * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2
+                    \tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]
+                       * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2
+                    \tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.2), 177376K [recommended]
+                    SOFTWAREUPDATE_LIST
+                   )
+    end
+    it 'returns the latest recommended Command Line Tools product' do
+      clt = MacOS::CommandLineTools.new
+      expect(clt.product).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2'
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures the `xcode-install` gem can be installed into Chef gems by verifying that Command Line Tools are installed. If not installed, a temporary file is created to trigger the `softwareupdate -l` command into providing the product name for the latest CLT, which is then downloaded and installed.

Fixes #79.