### PR TITLE
Allow node attributes to be set for Apple ID credentials, increase install timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ the `package`, `version` and `checksum` attributes in order to override.
 
 ### Xcode
 
-Installs Xcode 9.1 and simulators for iOS 10 and iOS 11. See the
+Installs Xcode 9.2 and simulators for iOS 10 and iOS 11. See the
 [Xcode resource documentation](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_xcode.md) if you need
 more flexibility.
 
-:warning: Requires a `credentials` data bag containing an `apple_id` data bag item.
+:warning: Requires a `credentials` data bag containing an `apple_id` data bag item,
+or a user/password pair set under `node['macos']['apple_id']`.
 
 **Usage:** `include_recipe macos::xcode`
 
@@ -93,6 +94,8 @@ more flexibility.
 |--------------------------------------------------------|---------------|
 | `node['macos']['xcode']['version']`                    | `'9.2'`       |
 | `node['macos']['xcode']['simulator']['major_version']` | `[11, 10]`    |
+| `node['macos']['apple_id']['user']`                    | `nil`         |
+| `node['macos']['apple_id']['password']`                | `nil`         |
 
 ### Apple Configurator 2
 

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -9,12 +9,14 @@ module MacOS
         installed_xcodes.include?(semantic_version)
       end
 
-      def find_apple_id(data_bag_retrieval, node_attributes)
-        data_bag_retrieval.call
+      def find_apple_id(data_bag_retrieval, node_credential_attributes)
+        if node_credential_attributes
+          { 'apple_id' => node_credential_attributes['user'],
+            'password' => node_credential_attributes['password'] }
+        else
+          data_bag_retrieval.call
+        end
       rescue Net::HTTPServerException
-        { 'apple_id' => node_attributes['user'],
-          'password' => node_attributes['password'] }
-      rescue NoMethodError
         Chef::Application.fatal!('No developer credentials supplied!')
       end
     end

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -13,6 +13,15 @@ module MacOS
         xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
         node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
       end
+
+      def find_apple_id(data_bag_retrieval, node_attributes)
+        data_bag_retrieval.call
+      rescue Net::HTTPServerException
+        { 'apple_id' => node_attributes['user'],
+          'password' => node_attributes['password'] }
+      rescue NoMethodError
+        Chef::Application.fatal!('No developer credentials supplied!')
+      end
     end
 
     class Simulator

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -9,11 +9,6 @@ module MacOS
         installed_xcodes.include?(semantic_version)
       end
 
-      def bundle_version_correct?
-        xcode_version = '/Applications/Xcode.app/Contents/version.plist CFBundleShortVersionString'
-        node['macos']['xcode']['version'] == shell_out("defaults read #{xcode_version}").stdout.strip
-      end
-
       def find_apple_id(data_bag_retrieval, node_attributes)
         data_bag_retrieval.call
       rescue Net::HTTPServerException

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -23,11 +23,13 @@ action :setup do
     options('--no-document --no-user-install')
   end
 
-  CREDENTIALS_DATA_BAG = data_bag_item(:credentials, :apple_id)
+  credentials = Xcode.find_apple_id(
+    -> { data_bag_item(:credentials, :apple_id) },
+    node['macos']['apple_id'])
 
   DEVELOPER_CREDENTIALS = {
-    XCODE_INSTALL_USER:     CREDENTIALS_DATA_BAG['apple_id'],
-    XCODE_INSTALL_PASSWORD: CREDENTIALS_DATA_BAG['password'],
+    XCODE_INSTALL_USER:     credentials['apple_id'],
+    XCODE_INSTALL_PASSWORD: credentials['password'],
   }.freeze
 
   execute 'update available Xcode versions' do

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -41,6 +41,7 @@ action :install_xcode do
     environment DEVELOPER_CREDENTIALS
     command XCVersion.install_xcode(new_resource.version)
     not_if { Xcode.installed?(new_resource.version) }
+    timeout 7200
   end
 end
 


### PR DESCRIPTION
This PR allows node attributes to be set for Developer Apple ID credentials while downloading Xcode from Apple: 

```
node['macos']['apple_id']['user']
node['macos']['apple_id']['password']
```
This PR also increases the timeout for the Xcode download and install process to 2 hours, and deletes a library method `bundle_version_correct?` since it doesn't work (unsuccessfully tries to access node attributes in Xcode library).

Fixes #80 and #76.

