### PR TITLE
don't install n-1 simulator by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ default['macos']['mono']['version'] = '4.4.2'
 default['macos']['mono']['checksum'] = 'd8bfbee7ae4d0d1facaf0ddfb70c0de4b1a3d94bb1b4c38e8fa4884539f54e23'
 
 default['macos']['xcode']['version'] = '9.2'
-default['macos']['xcode']['simulator']['major_version'] = %w(11 10)
+default['macos']['xcode']['simulator']['major_version'] = ['11']
 
 default['macos']['remote_login_enabled'] = true
 default['macos']['disk_sleep_disabled'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '~> 13.0' if respond_to?(:chef_version)
-version '1.10.0'
+version '1.10.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'


### PR DESCRIPTION
This PR installs only the current iOS Simulator by default when using the Xcode recipe. 