### PR TITLE
Issue 91 Fix: Add documentation for macos_user resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Resources
 - [ARD (Apple Remote Desktop)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_ard.md)
 - [Certificate (security)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_certificate.md)
 - [Machine Name](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_machine_name.md)
+- [Macos User](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_macos_user.md)
 - [Plist](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_plist.md)
 - [Spotlight (mdutil)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_spotlight.md)
 - [Xcode](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_xcode.md)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Resources
 - [ARD (Apple Remote Desktop)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_ard.md)
 - [Certificate (security)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_certificate.md)
 - [Machine Name](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_machine_name.md)
-- [Macos User](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_macos_user.md)
+- [Macos User (sysadminctl)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_macos_user.md)
 - [Plist](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_plist.md)
 - [Spotlight (mdutil)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_spotlight.md)
 - [Xcode](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_xcode.md)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Resources
 - [ARD (Apple Remote Desktop)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_ard.md)
 - [Certificate (security)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_certificate.md)
 - [Machine Name](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_machine_name.md)
-- [Macos User (sysadminctl)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_macos_user.md)
+- [macOS User (sysadminctl)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_macos_user.md)
 - [Plist](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_plist.md)
 - [Spotlight (mdutil)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_spotlight.md)
 - [Xcode](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_xcode.md)

--- a/documentation/resource_macos_user.md
+++ b/documentation/resource_macos_user.md
@@ -72,7 +72,7 @@ macos_user 'create user' do
 end
 ```
 
-**Create a user that has a fullnames**
+**Create a user that has a fullname**
 
 ```ruby
 macos_user 'create user' do

--- a/documentation/resource_macos_user.md
+++ b/documentation/resource_macos_user.md
@@ -1,0 +1,72 @@
+macos_user
+=========
+
+Use the **macos_user** resource to manage user creation.
+Under the hood, a **macos_user** resource executes the `sysadminctl`
+command.
+
+Syntax
+------
+
+The full syntax for all of the properties available to the **macos_user** resource
+is:
+
+```ruby
+macos_user 'user and action description' do
+  username             String          # username for user
+  password             String          # password for user, defaults to "password" if not specified
+  autologin            TrueClass       # user autologin
+  admin                TrueClass       # admin status of user
+  fullname             String          # full name of user
+  groups               Array, String   # list of groups the user is in
+end
+```
+
+Actions
+-------
+
+`:create`
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Create a user specified by
+`macos_user` properties. This is the default action.
+
+`:delete`
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Delete a user specified by
+the `macos_user` username property. 
+
+
+Examples
+--------
+
+**Create a user with admin privileges**
+
+```ruby
+macos_user 'create admin user' do
+  username 'mscott'
+  password '1234'
+  autologin true
+  admin     true
+end
+```
+
+**Create a user that is part of several groups**
+
+```ruby
+macos_user 'create user' do
+  username 'pbeesly'
+  password 'cecelia'
+  groups   ['reception', 'sales', 'coalition']
+end
+```
+
+**Create a user that has a fullnames**
+
+```ruby
+macos_user 'create user' do
+  username 'omartinez'
+  fullname 'Oscar Martinez'
+  password 'tacobelldog'
+  groups   ['accounting']
+end
+```

--- a/documentation/resource_macos_user.md
+++ b/documentation/resource_macos_user.md
@@ -22,6 +22,18 @@ macos_user 'user and action description' do
 end
 ```
 
+The following example is equivalent to issuing ```"sysadminctl  -addUser jlevinson -password serenity -admin"```
+
+```ruby
+macos_user 'create admin user' do
+  username 'jlevinson'
+  password 'serenity'
+  admin     true
+end
+```
+
+
+
 Actions
 -------
 
@@ -66,7 +78,7 @@ end
 macos_user 'create user' do
   username 'omartinez'
   fullname 'Oscar Martinez'
-  password 'tacobelldog'
+  password 'reason'
   groups   ['accounting']
 end
 ```


### PR DESCRIPTION
**macos_user resource is missing documentation**

Added resource_macos_user.md in the documentation directory and updated the README.md to point to it. 