### PR TITLE
Skip disk sleep integration tests, update README

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,6 +62,8 @@ suites:
     - updates-disabled
 
 - name: power-management
+  provisioner:
+    multiple_converge: 2
   run_list:
   - recipe[macos::keep_awake]
   verifier:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 macOS Cookbook
 ==============
 
-The macOS cookbook is a Chef library cookbook that provides resources for configuring
-and provisioning macOS. Additionally, it provides recipes that implement common
-use-cases of the macOS cookbook's resources.
+![build-status-badge](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2143/badge)
+
+Chef resources and recipes for managing and provisioning macOS.
 
 - [Chef Requirements](#chef-requirements)
 - [Supported OS Versions](#supported-os-versions)
@@ -12,19 +12,18 @@ use-cases of the macOS cookbook's resources.
 - [Data Bags](#data-bags)
 - [Resources](#resources)
 
-Chef Requirements
------------------
+Supported Chef Versions
+-----------------------
 
-Currently, we've only tested the macOS cookbook using **Chef 13**. We do intend to implement
-better test coverage in order to support more versions of Chef. Let us know
-if you find issues with previous versions and we will do our best to resolve them.
+- Chef 13
+- Chef 14
 
 Supported OS Versions
 ---------------------
 
-| OS X El Capitan 10.11 | macOS Sierra 10.12 | macOS High Sierra 10.13 |
-|:---------------------:|:------------------:|:-----------------------:|
-| ![build-status-1011](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2302/badge) | ![build-status-1012](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2140/badge) | ![build-status-1013](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2143/badge) |
+- OS X El Capitan 10.11
+- macOS Sierra 10.12
+- macOS High Sierra 10.13
 
 Attributes
 ----------
@@ -92,8 +91,8 @@ or a user/password pair set under `node['macos']['apple_id']`.
 
 | Attributes used                                        | Default value |
 |--------------------------------------------------------|---------------|
-| `node['macos']['xcode']['version']`                    | `'9.2'`       |
-| `node['macos']['xcode']['simulator']['major_version']` | `[11, 10]`    |
+| `node['macos']['xcode']['version']`                    | `'9.3'`       |
+| `node['macos']['xcode']['simulator']['major_version']` | `nil`         |
 | `node['macos']['apple_id']['user']`                    | `nil`         |
 | `node['macos']['apple_id']['password']`                | `nil`         |
 

--- a/test/integration/default/controls/energy_saver.rb
+++ b/test/integration/default/controls/energy_saver.rb
@@ -45,7 +45,7 @@ control 'no-sleep' do
     its('stdout') { should match(/Never/) }
   end
 
-  describe command('systemsetup -getharddisksleep') do
+  describe command('systemsetup -getharddisksleep'), :skip do
     its('stdout') { should match(/after 10 minutes/) }
   end
 
@@ -57,7 +57,7 @@ control 'no-sleep' do
     its('stdout') { should match(/sleep\s+0/) }
   end
 
-  describe command('pmset -g') do
+  describe command('pmset -g'), :skip do
     its('stdout') { should match(/disksleep\s+10/) }
   end
 

--- a/test/integration/default/controls/energy_saver.rb
+++ b/test/integration/default/controls/energy_saver.rb
@@ -45,7 +45,7 @@ control 'no-sleep' do
     its('stdout') { should match(/Never/) }
   end
 
-  describe command('systemsetup -getharddisksleep'), :skip do
+  describe command('systemsetup -getharddisksleep') do
     its('stdout') { should match(/after 10 minutes/) }
   end
 
@@ -57,7 +57,7 @@ control 'no-sleep' do
     its('stdout') { should match(/sleep\s+0/) }
   end
 
-  describe command('pmset -g'), :skip do
+  describe command('pmset -g') do
     its('stdout') { should match(/disksleep\s+10/) }
   end
 


### PR DESCRIPTION
- We are skipping the disk sleep tests temporarily since there have been
intermittent failures with that setting in particular. We think it may
be a race condition or potentially a bug with `kitchen test`
- Update the README to include the parallel CI badge -- the current
build definition tests the entire kitchen test matrix in parallel
- Update the README with the correct Xcode recipe attributes