### PR TITLE
Clean up spec tests

### DIFF
--- a/spec/unit/libraries/plist_spec.rb
+++ b/spec/unit/libraries/plist_spec.rb
@@ -126,16 +126,6 @@ describe MacOS::PlistHelpers, '#convert_to_string_from_data_type' do
       expect(convert_to_string_from_data_type(true)).to eq 'bool true'
     end
 
-    # TODO: Skip until proper array support is implemented (i.e. containers)
-    xit 'returns the required array entry' do
-      expect(convert_to_string_from_data_type(%w(foo bar))).to eq 'array foo bar'
-    end
-
-    # TODO: Skip until proper dict support is implemented (i.e. containers)
-    xit 'returns the required dictionary entry' do
-      expect(convert_to_string_from_data_type('baz' => 'qux')).to eq 'dict key value'
-    end
-
     it 'returns the required string entry' do
       expect(convert_to_string_from_data_type('quux')).to eq 'string quux'
     end

--- a/spec/unit/libraries/system_spec.rb
+++ b/spec/unit/libraries/system_spec.rb
@@ -7,12 +7,6 @@ describe MacOS::System::FormFactor do
     it 'it registers as form factor type desktop' do
       ff = MacOS::System::FormFactor.new('MacMini')
       expect(ff.desktop?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has MacMini' do
-    it 'it does not register as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('MacMini')
       expect(ff.portable?).to eq false
     end
   end
@@ -21,12 +15,6 @@ describe MacOS::System::FormFactor do
     it 'it registers as form factor type desktop' do
       ff = MacOS::System::FormFactor.new('MacPro')
       expect(ff.desktop?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has MacPro' do
-    it 'it does not register as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('MacPro')
       expect(ff.portable?).to eq false
     end
   end
@@ -35,12 +23,6 @@ describe MacOS::System::FormFactor do
     it 'it registers as form factor type desktop' do
       ff = MacOS::System::FormFactor.new('iMac')
       expect(ff.desktop?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has iMac' do
-    it 'it does not register as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('iMac')
       expect(ff.portable?).to eq false
     end
   end
@@ -49,12 +31,6 @@ describe MacOS::System::FormFactor do
     it 'registers as form factor type portable' do
       ff = MacOS::System::FormFactor.new('Macbook')
       expect(ff.portable?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has Macbook' do
-    it 'it does not register as form factor desktop' do
-      ff = MacOS::System::FormFactor.new('Macbook')
       expect(ff.desktop?).to eq false
     end
   end
@@ -63,12 +39,6 @@ describe MacOS::System::FormFactor do
     it 'it does not register as form factor desktop' do
       ff = MacOS::System::FormFactor.new('unknown')
       expect(ff.desktop?).to eq false
-    end
-  end
-
-  context 'when passed a machine model that is unknown' do
-    it 'it does not register as form factor portable' do
-      ff = MacOS::System::FormFactor.new('unknown')
       expect(ff.portable?).to eq false
     end
   end
@@ -77,12 +47,6 @@ describe MacOS::System::FormFactor do
     it 'it does not register as form factor desktop' do
       ff = MacOS::System::FormFactor.new(nil)
       expect(ff.desktop?).to eq false
-    end
-  end
-
-  context 'when passed a machine model that is nil' do
-    it 'it does not register as form factor portable' do
-      ff = MacOS::System::FormFactor.new(nil)
       expect(ff.portable?).to eq false
     end
   end
@@ -117,22 +81,12 @@ describe MacOS::System::ScreenSaver do
       screen = MacOS::System::ScreenSaver.new('vagrant')
       expect(screen.query('read').command).to eq ['defaults', '-currentHost', 'read', 'com.apple.screensaver', 'idleTime']
     end
-
-    it 'returns a defaults read command' do
-      screen = MacOS::System::ScreenSaver.new('vagrant')
-      expect(screen.query('read').command).should_not eq ['defaults', '-currentHost', 'read-type', 'com.apple.screensaver', 'idleTime']
-    end
   end
 
   context 'querying a read-type for idleTime' do
     it 'returns a defaults read-type command' do
       screen = MacOS::System::ScreenSaver.new('vagrant')
       expect(screen.query('read-type').command).to eq ['defaults', '-currentHost', 'read-type', 'com.apple.screensaver', 'idleTime']
-    end
-
-    it 'returns a defaults read-type command' do
-      screen = MacOS::System::ScreenSaver.new('vagrant')
-      expect(screen.query('read-type').command).should_not eq ['defaults', '-currentHost', 'read', 'com.apple.screensaver', 'idleTime']
     end
   end
 


### PR DESCRIPTION
This PR cleans up some spec tests from `system_spec` to share the same `context` block and run as the same test. It also removes some over-testing (`should_not`).

It also removes some tests from `plist-spec`  that have been skipped since forever, since we don't implement what they test.