### PR TITLE
Don't require stubbing `machine_model` when wrapping `keep_awake`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,6 @@ to always keep macOS on and available.
 | `node['macos']['network_time_server']`  | `'time.windows.com'`    |
 | `node['macos']['time_zone']`            | `'America/Los_Angeles'` |
 
-**N.b.** When ChefSpec testing implementations of this recipe, the `node['hardware']['machine_model']`
-attribute needs to be set to a Mac model identifier, e.g. `MacMini6,2`, in order
-for tests to pass:
-
-```ruby
-let(:chef_run) do
-  ChefSpec::SoloRunner.new do |node|
-    node.normal['hardware']['machine_model'] = 'MacMini6,2'
-  end.converge(described_recipe)
-end
-```
-
 ### Mono
 
 Installs [Mono](http://www.mono-project.com/docs/about-mono/). Requires setting

--- a/libraries/system.rb
+++ b/libraries/system.rb
@@ -3,8 +3,8 @@ module MacOS
     class FormFactor
       attr_reader :machine_model
 
-      def initialize(machine_model)
-        @machine_model = machine_model
+      def initialize(hardware)
+        @machine_model = hardware.nil? ? nil : hardware['machine_model']
       end
 
       def desktop?

--- a/libraries/system.rb
+++ b/libraries/system.rb
@@ -9,12 +9,12 @@ module MacOS
 
       def desktop?
         return false if @machine_model.nil?
-        @machine_model.match? Regexp.union %w(MacMini MacPro iMac)
+        @machine_model.match? Regexp.union %w(Macmini MacPro iMac)
       end
 
       def portable?
         return false if @machine_model.nil?
-        @machine_model.match? Regexp.union %w(Macbook)
+        @machine_model.match? Regexp.union %w(MacBook)
       end
     end
 

--- a/recipes/keep_awake.rb
+++ b/recipes/keep_awake.rb
@@ -1,4 +1,4 @@
-form_factor = MacOS::System::FormFactor.new(node['hardware']['machine_model'])
+form_factor = MacOS::System::FormFactor.new(node['hardware'])
 environment = MacOS::System::Environment.new(node['virtualization']['systems'])
 screensaver = MacOS::System::ScreenSaver.new(node['macos']['admin_user'])
 

--- a/spec/unit/libraries/system_spec.rb
+++ b/spec/unit/libraries/system_spec.rb
@@ -5,7 +5,7 @@ include MacOS::System
 describe MacOS::System::FormFactor do
   context 'when passed a machine model that has MacMini' do
     it 'it registers as form factor type desktop' do
-      ff = MacOS::System::FormFactor.new('MacMini')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'Macmini7,1')
       expect(ff.desktop?).to eq true
       expect(ff.portable?).to eq false
     end
@@ -13,7 +13,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that has MacPro' do
     it 'it registers as form factor type desktop' do
-      ff = MacOS::System::FormFactor.new('MacPro')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'MacPro6,1')
       expect(ff.desktop?).to eq true
       expect(ff.portable?).to eq false
     end
@@ -21,7 +21,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that has iMac' do
     it 'it registers as form factor type desktop' do
-      ff = MacOS::System::FormFactor.new('iMac')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'iMac18,3')
       expect(ff.desktop?).to eq true
       expect(ff.portable?).to eq false
     end
@@ -29,7 +29,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that has Macbook' do
     it 'registers as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('Macbook')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'MacBookPro14,3')
       expect(ff.portable?).to eq true
       expect(ff.desktop?).to eq false
     end
@@ -37,7 +37,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that is unknown' do
     it 'it does not register as form factor desktop' do
-      ff = MacOS::System::FormFactor.new('unknown')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'unknown')
       expect(ff.desktop?).to eq false
       expect(ff.portable?).to eq false
     end

--- a/spec/unit/recipes/keep_awake_spec.rb
+++ b/spec/unit/recipes/keep_awake_spec.rb
@@ -5,7 +5,7 @@ include MacOS::System
 shared_context 'when running on bare metal macmini' do
   before(:each) do
     chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'parallels' => 'host' }
-    chef_run.node.normal['hardware']['machine_model'] = 'MacMini6,2'
+    chef_run.node.normal['hardware']['machine_model'] = 'Macmini7,1'
   end
 
   shared_examples 'setting metal-specific power preferences' do
@@ -33,7 +33,7 @@ end
 shared_context 'when running on bare metal macbook' do
   before(:each) do
     chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'parallels' => 'host' }
-    chef_run.node.normal['hardware']['machine_model'] = 'Macbook10,1'
+    chef_run.node.normal['hardware']['machine_model'] = 'MacBook10,1'
   end
 
   shared_examples 'setting portable metal-specific power preferences' do

--- a/spec/unit/recipes/keep_awake_spec.rb
+++ b/spec/unit/recipes/keep_awake_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 include MacOS::System
 
-shared_context 'when running on bare metal macmini' do
+shared_context 'running on bare metal Mac Mini' do
   before(:each) do
-    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'parallels' => 'host' }
+    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'Parallels' => 'host' }
     chef_run.node.normal['hardware']['machine_model'] = 'Macmini7,1'
   end
 
-  shared_examples 'setting metal-specific power preferences' do
+  shared_examples 'including metal-specific power preferences' do
     it 'sets wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to set_system_preference('wake the computer when accessed using a network connection')
@@ -30,13 +30,13 @@ shared_context 'when running on bare metal macmini' do
   end
 end
 
-shared_context 'when running on bare metal macbook' do
+shared_context 'when running on bare metal MacBook Pro' do
   before(:each) do
-    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'parallels' => 'host' }
-    chef_run.node.normal['hardware']['machine_model'] = 'MacBook10,1'
+    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'Parallels' => 'host' }
+    chef_run.node.normal['hardware']['machine_model'] = 'MacBookPro14,3'
   end
 
-  shared_examples 'setting portable metal-specific power preferences' do
+  shared_examples 'including metal-specific power preferences for portables' do
     it 'sets wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to set_system_preference('wake the computer when accessed using a network connection')
@@ -53,13 +53,13 @@ shared_context 'when running on bare metal macbook' do
   end
 end
 
-shared_context 'running in a parallels virtual machine' do
+shared_context 'running in a Parallels virtual machine' do
   before(:each) do
-    chef_run.node.normal['virtualization']['systems'] = { 'parallels' => 'guest' }
+    chef_run.node.normal['virtualization']['systems'] = { 'Parallels' => 'guest' }
     chef_run.node.normal['hardware']['machine_model'] = 'Parallels13,1'
   end
 
-  shared_examples 'not setting metal-specific power prefs' do
+  shared_examples 'ignoring metal-specific power preferences' do
     it 'does not set wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to_not set_system_preference('wake the computer when accessed using a network connection')
@@ -86,7 +86,7 @@ shared_context 'running in an undetermined virtualization system' do
     chef_run.node.normal['hardware']['machine_model'] = ''
   end
 
-  shared_examples 'not setting metal-specific power prefs' do
+  shared_examples 'ignoring metal-specific power preferences' do
     it 'does not set wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to_not set_system_preference('wake the computer when accessed using a network connection')
@@ -111,23 +111,23 @@ end
 describe 'macos::keep_awake' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
-  describe 'keep_awake in a parallels vm' do
-    include_context 'running in a parallels virtual machine'
-    it_behaves_like 'not setting metal-specific power prefs'
+  describe 'keep_awake in a Parallels VM' do
+    include_context 'running in a Parallels virtual machine'
+    it_behaves_like 'ignoring metal-specific power preferences'
   end
 
   describe 'keep_awake in an undetermined virtualization system' do
     include_context 'running in an undetermined virtualization system'
-    it_behaves_like 'not setting metal-specific power prefs'
+    it_behaves_like 'ignoring metal-specific power preferences'
   end
 
   describe 'keep_awake on bare metal' do
-    include_context 'when running on bare metal macmini'
-    it_behaves_like 'setting metal-specific power preferences'
+    include_context 'running on bare metal Mac Mini'
+    it_behaves_like 'including metal-specific power preferences'
   end
 
   describe 'keep_awake on portable bare metal' do
-    include_context 'when running on bare metal macbook'
-    it_behaves_like 'setting portable metal-specific power preferences'
+    include_context 'when running on bare metal MacBook Pro'
+    it_behaves_like 'including metal-specific power preferences for portables'
   end
 end


### PR DESCRIPTION
This PR removes the need to stub the `node['hardware']['machine_model']` attribute for ChefSpec testing of cookbooks that wrap the `keep_awake` recipe. It also removes the documentation stating that it is required to pass tests. 