### PR TITLE
Release/1.14

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -64,18 +64,6 @@ to always keep macOS on and available.
 | `node['macos']['network_time_server']`  | `'time.windows.com'`    |
 | `node['macos']['time_zone']`            | `'America/Los_Angeles'` |
 
-**N.b.** When ChefSpec testing implementations of this recipe, the `node['hardware']['machine_model']`
-attribute needs to be set to a Mac model identifier, e.g. `MacMini6,2`, in order
-for tests to pass:
-
-```ruby
-let(:chef_run) do
-  ChefSpec::SoloRunner.new do |node|
-    node.normal['hardware']['machine_model'] = 'MacMini6,2'
-  end.converge(described_recipe)
-end
-```
-
 ### Mono
 
 Installs [Mono](http://www.mono-project.com/docs/about-mono/). Requires setting

--- a/libraries/system.rb
+++ b/libraries/system.rb
@@ -3,18 +3,18 @@ module MacOS
     class FormFactor
       attr_reader :machine_model
 
-      def initialize(machine_model)
-        @machine_model = machine_model
+      def initialize(hardware)
+        @machine_model = hardware.nil? ? nil : hardware['machine_model']
       end
 
       def desktop?
         return false if @machine_model.nil?
-        @machine_model.match? Regexp.union %w(MacMini MacPro iMac)
+        @machine_model.match? Regexp.union %w(Macmini MacPro iMac)
       end
 
       def portable?
         return false if @machine_model.nil?
-        @machine_model.match? Regexp.union %w(Macbook)
+        @machine_model.match? Regexp.union %w(MacBook)
       end
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '1.13.1'
+version '1.14'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/recipes/keep_awake.rb
+++ b/recipes/keep_awake.rb
@@ -1,4 +1,4 @@
-form_factor = MacOS::System::FormFactor.new(node['hardware']['machine_model'])
+form_factor = MacOS::System::FormFactor.new(node['hardware'])
 environment = MacOS::System::Environment.new(node['virtualization']['systems'])
 screensaver = MacOS::System::ScreenSaver.new(node['macos']['admin_user'])
 

--- a/spec/unit/libraries/plist_spec.rb
+++ b/spec/unit/libraries/plist_spec.rb
@@ -126,16 +126,6 @@ describe MacOS::PlistHelpers, '#convert_to_string_from_data_type' do
       expect(convert_to_string_from_data_type(true)).to eq 'bool true'
     end
 
-    # TODO: Skip until proper array support is implemented (i.e. containers)
-    xit 'returns the required array entry' do
-      expect(convert_to_string_from_data_type(%w(foo bar))).to eq 'array foo bar'
-    end
-
-    # TODO: Skip until proper dict support is implemented (i.e. containers)
-    xit 'returns the required dictionary entry' do
-      expect(convert_to_string_from_data_type('baz' => 'qux')).to eq 'dict key value'
-    end
-
     it 'returns the required string entry' do
       expect(convert_to_string_from_data_type('quux')).to eq 'string quux'
     end

--- a/spec/unit/libraries/system_spec.rb
+++ b/spec/unit/libraries/system_spec.rb
@@ -7,12 +7,6 @@ describe MacOS::System::FormFactor do
     it 'it registers as form factor type desktop' do
       ff = MacOS::System::FormFactor.new('MacMini')
       expect(ff.desktop?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has MacMini' do
-    it 'it does not register as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('MacMini')
       expect(ff.portable?).to eq false
     end
   end
@@ -21,12 +15,6 @@ describe MacOS::System::FormFactor do
     it 'it registers as form factor type desktop' do
       ff = MacOS::System::FormFactor.new('MacPro')
       expect(ff.desktop?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has MacPro' do
-    it 'it does not register as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('MacPro')
       expect(ff.portable?).to eq false
     end
   end
@@ -35,12 +23,6 @@ describe MacOS::System::FormFactor do
     it 'it registers as form factor type desktop' do
       ff = MacOS::System::FormFactor.new('iMac')
       expect(ff.desktop?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has iMac' do
-    it 'it does not register as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('iMac')
       expect(ff.portable?).to eq false
     end
   end
@@ -49,12 +31,6 @@ describe MacOS::System::FormFactor do
     it 'registers as form factor type portable' do
       ff = MacOS::System::FormFactor.new('Macbook')
       expect(ff.portable?).to eq true
-    end
-  end
-
-  context 'when passed a machine model that has Macbook' do
-    it 'it does not register as form factor desktop' do
-      ff = MacOS::System::FormFactor.new('Macbook')
       expect(ff.desktop?).to eq false
     end
   end
@@ -63,12 +39,6 @@ describe MacOS::System::FormFactor do
     it 'it does not register as form factor desktop' do
       ff = MacOS::System::FormFactor.new('unknown')
       expect(ff.desktop?).to eq false
-    end
-  end
-
-  context 'when passed a machine model that is unknown' do
-    it 'it does not register as form factor portable' do
-      ff = MacOS::System::FormFactor.new('unknown')
       expect(ff.portable?).to eq false
     end
   end
@@ -77,12 +47,6 @@ describe MacOS::System::FormFactor do
     it 'it does not register as form factor desktop' do
       ff = MacOS::System::FormFactor.new(nil)
       expect(ff.desktop?).to eq false
-    end
-  end
-
-  context 'when passed a machine model that is nil' do
-    it 'it does not register as form factor portable' do
-      ff = MacOS::System::FormFactor.new(nil)
       expect(ff.portable?).to eq false
     end
   end
@@ -117,22 +81,12 @@ describe MacOS::System::ScreenSaver do
       screen = MacOS::System::ScreenSaver.new('vagrant')
       expect(screen.query('read').command).to eq ['defaults', '-currentHost', 'read', 'com.apple.screensaver', 'idleTime']
     end
-
-    it 'returns a defaults read command' do
-      screen = MacOS::System::ScreenSaver.new('vagrant')
-      expect(screen.query('read').command).should_not eq ['defaults', '-currentHost', 'read-type', 'com.apple.screensaver', 'idleTime']
-    end
   end
 
   context 'querying a read-type for idleTime' do
     it 'returns a defaults read-type command' do
       screen = MacOS::System::ScreenSaver.new('vagrant')
       expect(screen.query('read-type').command).to eq ['defaults', '-currentHost', 'read-type', 'com.apple.screensaver', 'idleTime']
-    end
-
-    it 'returns a defaults read-type command' do
-      screen = MacOS::System::ScreenSaver.new('vagrant')
-      expect(screen.query('read-type').command).should_not eq ['defaults', '-currentHost', 'read', 'com.apple.screensaver', 'idleTime']
     end
   end
 

--- a/spec/unit/libraries/system_spec.rb
+++ b/spec/unit/libraries/system_spec.rb
@@ -5,7 +5,7 @@ include MacOS::System
 describe MacOS::System::FormFactor do
   context 'when passed a machine model that has MacMini' do
     it 'it registers as form factor type desktop' do
-      ff = MacOS::System::FormFactor.new('MacMini')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'Macmini7,1')
       expect(ff.desktop?).to eq true
       expect(ff.portable?).to eq false
     end
@@ -13,7 +13,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that has MacPro' do
     it 'it registers as form factor type desktop' do
-      ff = MacOS::System::FormFactor.new('MacPro')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'MacPro6,1')
       expect(ff.desktop?).to eq true
       expect(ff.portable?).to eq false
     end
@@ -21,7 +21,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that has iMac' do
     it 'it registers as form factor type desktop' do
-      ff = MacOS::System::FormFactor.new('iMac')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'iMac18,3')
       expect(ff.desktop?).to eq true
       expect(ff.portable?).to eq false
     end
@@ -29,7 +29,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that has Macbook' do
     it 'registers as form factor type portable' do
-      ff = MacOS::System::FormFactor.new('Macbook')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'MacBookPro14,3')
       expect(ff.portable?).to eq true
       expect(ff.desktop?).to eq false
     end
@@ -37,7 +37,7 @@ describe MacOS::System::FormFactor do
 
   context 'when passed a machine model that is unknown' do
     it 'it does not register as form factor desktop' do
-      ff = MacOS::System::FormFactor.new('unknown')
+      ff = MacOS::System::FormFactor.new('machine_model' => 'unknown')
       expect(ff.desktop?).to eq false
       expect(ff.portable?).to eq false
     end

--- a/spec/unit/recipes/keep_awake_spec.rb
+++ b/spec/unit/recipes/keep_awake_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 include MacOS::System
 
-shared_context 'when running on bare metal macmini' do
+shared_context 'running on bare metal Mac Mini' do
   before(:each) do
-    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'parallels' => 'host' }
-    chef_run.node.normal['hardware']['machine_model'] = 'MacMini6,2'
+    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'Parallels' => 'host' }
+    chef_run.node.normal['hardware']['machine_model'] = 'Macmini7,1'
   end
 
-  shared_examples 'setting metal-specific power preferences' do
+  shared_examples 'including metal-specific power preferences' do
     it 'sets wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to set_system_preference('wake the computer when accessed using a network connection')
@@ -30,13 +30,13 @@ shared_context 'when running on bare metal macmini' do
   end
 end
 
-shared_context 'when running on bare metal macbook' do
+shared_context 'when running on bare metal MacBook Pro' do
   before(:each) do
-    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'parallels' => 'host' }
-    chef_run.node.normal['hardware']['machine_model'] = 'Macbook10,1'
+    chef_run.node.normal['virtualization']['systems'] = { 'vbox' => 'host', 'Parallels' => 'host' }
+    chef_run.node.normal['hardware']['machine_model'] = 'MacBookPro14,3'
   end
 
-  shared_examples 'setting portable metal-specific power preferences' do
+  shared_examples 'including metal-specific power preferences for portables' do
     it 'sets wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to set_system_preference('wake the computer when accessed using a network connection')
@@ -53,13 +53,13 @@ shared_context 'when running on bare metal macbook' do
   end
 end
 
-shared_context 'running in a parallels virtual machine' do
+shared_context 'running in a Parallels virtual machine' do
   before(:each) do
-    chef_run.node.normal['virtualization']['systems'] = { 'parallels' => 'guest' }
+    chef_run.node.normal['virtualization']['systems'] = { 'Parallels' => 'guest' }
     chef_run.node.normal['hardware']['machine_model'] = 'Parallels13,1'
   end
 
-  shared_examples 'not setting metal-specific power prefs' do
+  shared_examples 'ignoring metal-specific power preferences' do
     it 'does not set wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to_not set_system_preference('wake the computer when accessed using a network connection')
@@ -86,7 +86,7 @@ shared_context 'running in an undetermined virtualization system' do
     chef_run.node.normal['hardware']['machine_model'] = ''
   end
 
-  shared_examples 'not setting metal-specific power prefs' do
+  shared_examples 'ignoring metal-specific power preferences' do
     it 'does not set wake on lan' do
       chef_run.converge(described_recipe)
       expect(chef_run).to_not set_system_preference('wake the computer when accessed using a network connection')
@@ -111,23 +111,23 @@ end
 describe 'macos::keep_awake' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
-  describe 'keep_awake in a parallels vm' do
-    include_context 'running in a parallels virtual machine'
-    it_behaves_like 'not setting metal-specific power prefs'
+  describe 'keep_awake in a Parallels VM' do
+    include_context 'running in a Parallels virtual machine'
+    it_behaves_like 'ignoring metal-specific power preferences'
   end
 
   describe 'keep_awake in an undetermined virtualization system' do
     include_context 'running in an undetermined virtualization system'
-    it_behaves_like 'not setting metal-specific power prefs'
+    it_behaves_like 'ignoring metal-specific power preferences'
   end
 
   describe 'keep_awake on bare metal' do
-    include_context 'when running on bare metal macmini'
-    it_behaves_like 'setting metal-specific power preferences'
+    include_context 'running on bare metal Mac Mini'
+    it_behaves_like 'including metal-specific power preferences'
   end
 
   describe 'keep_awake on portable bare metal' do
-    include_context 'when running on bare metal macbook'
-    it_behaves_like 'setting portable metal-specific power preferences'
+    include_context 'when running on bare metal MacBook Pro'
+    it_behaves_like 'including metal-specific power preferences for portables'
   end
 end


### PR DESCRIPTION
This PR updates the `keep_awake` recipe and spec tests to not require node attribute stubbing when wrapped in another cookbook. 

It also removes some extra specs tests where logic was overtested (`should_not eq`) and updates some of the spec language for clarity. 