### PR TITLE
Make sure version has three numbers

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '1.14'
+version '1.14.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'


### PR DESCRIPTION
We deployed version `1.14` to the Supermarket (without the third number), but we are getting an error when attempting to install that version using `berks`. This may be a bug in `berks` since Chef's documentation states that:

> A cookbook version always takes the form x.y.z, where x, y, and z are decimal numbers that are used to represent major (x), minor (y), and patch (z) versions. A two-part version (x.y) is also allowed. Alphanumeric version numbers (1.2.a3) and version numbers with more than three parts (1.2.3.4) are not allowed.

When a cookbook depends on `macos` and there is no `Berksfile.lock` we see the following behavior:

```
$ berks install
Cookbook 'macos' (1.14.0) not found in any of the sources! This can happen if the remote cookbook has been deleted or if the sources inside the Berksfile have changed. Please run `berks update macos` to resolve to a valid version.
$ berks update macos
Lockfile not found! Run `berks install` to create the lockfile.
```