### PR TITLE
Fix autologin functionality on 10.13.4

### DIFF
--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -14,7 +14,7 @@ action_class do
   end
 
   def setup_assistant_plist
-    ::File.join(user_home, '/Library/Preferences/com.apple.SetupAssistant.plist')
+    ::File.join(user_home, 'Library', 'Preferences', 'com.apple.SetupAssistant.plist')
   end
 
   def setup_assistant_keypair_values

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -10,7 +10,7 @@ property :groups, [Array, String]
 
 action_class do
   def user_home
-    ::File.join('/Users', new_resource.username)
+    ::File.join('/', 'Users', new_resource.username)
   end
 
   def setup_assistant_plist

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -17,12 +17,22 @@ action_class do
     ::File.join(user_home, 'Library', 'Preferences', 'com.apple.SetupAssistant.plist')
   end
 
+  def login_window_plist
+    ::File.join('/', 'Library', 'Preferences', 'com.apple.loginwindow.plist')
+  end
+
   def setup_assistant_keypair_values
     { 'DidSeeCloudSetup' => true,
       'DidSeeSiriSetup' => true,
       'DidSeePrivacy' => true,
       'LastSeenCloudProductVersion' => node['platform_version'],
       'LastSeenBuddyBuildVersion' => node['platform_build'],
+    }
+  end
+
+  def login_window_keypair_values
+    { 'autoLoginUser' => new_resource.username,
+      'lastUser' => 'loggedIn',
     }
   end
 
@@ -68,10 +78,11 @@ action :create do
       end
     end
 
-    plist "set user \"#{new_resource.username}\" to login automatically" do
-      path '/Library/Preferences/com.apple.loginwindow.plist'
-      entry 'autoLoginUser'
-      value new_resource.username
+    login_window_keypair_values.each do |e, v|
+      plist login_window_plist do
+        entry e
+        value v
+      end
     end
 
     file '/etc/kcpassword' do

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -18,9 +18,12 @@ action_class do
   end
 
   def setup_assistant_keypair_values
-    { 'DidSeeSiriSetup' => true,
-      'DidSeeCloudSetup' => true,
-      'LastSeenCloudProductVersion' => node['platform_version'] }
+    { 'DidSeeCloudSetup' => true,
+      'DidSeeSiriSetup' => true,
+      'DidSeePrivacy' => true,
+      'LastSeenCloudProductVersion' => node['platform_version'],
+      'LastSeenBuddyBuildVersion' => node['platform_build'],
+    }
   end
 
   def sysadminctl

--- a/test/integration/default/controls/users_and_groups.rb
+++ b/test/integration/default/controls/users_and_groups.rb
@@ -18,9 +18,23 @@ control 'admin-user' do
     its('stdout.split') { should include '80' }
   end
 
-  describe command("/usr/libexec/PlistBuddy -c 'Print :autoLoginUser' /Library/Preferences/com.apple.loginwindow.plist") do
-    its('exit_status') { should eq 0 }
-    its('stdout.chomp') { should eq 'randall' }
+  setup_assistant_keypair_values = { 'autoLoginUser' => 'randall',
+                                     'lastUser' => 'loggedIn',
+                                   }
+  setup_assistant_keypair_values.each do |key, expected_value|
+    describe command("/usr/libexec/Plistbuddy -c 'Print #{key}' /Library/Preferences/com.apple.loginwindow.plist") do
+      its('stdout.chomp') { should eq expected_value }
+    end
+  end
+
+  login_window_keypair_values = { 'DidSeeCloudSetup' => true,
+                                  'DidSeeSiriSetup' => true,
+                                  'DidSeePrivacy' => true,
+                                }
+  login_window_keypair_values.each do |key, expected_value|
+    describe command("/usr/libexec/Plistbuddy -c 'Print #{key}' /Users/randall/Library/Preferences/com.apple.SetupAssistant.plist") do
+      its('stdout.chomp') { should eq expected_value.to_s }
+    end
   end
 
   describe groups.where { name == 'admin' } do


### PR DESCRIPTION
This PR fixes an issue where the autologin user prompted for a password the first reboot after converge. I resolved this by adding `'lastUser' => 'loggedIn'` to the loginwindow plist - the default value causing the bug was `'lastUser' => 'Restart'`.

Resolving this bug also exposed that we were not dismissing the Data & Privacy setup pane new in 10.13.4. I added `'DidSeePrivacy' => true` to the user's SetupAssistant plist to dismiss this.