### PR TITLE
Adding guard config and rake tasks for testing convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.un~
 
 # Bundler
-Gemfile
 Gemfile.lock
 bin/*
 .bundle/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+group :development do
+  gem 'guard', require: false
+  gem 'guard-rspec', require: false
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,18 @@
+guard :rspec, cmd: 'chef exec rspec' do
+  require 'guard/rspec/dsl'
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  path_to_library_spec = ->(filename) { "spec/unit/libraries/#{filename}_spec.rb" }
+  watch(%r{^libraries/(.+)\.rb$}) { |m| path_to_library_spec.call(m[1]) }
+  watch(%r{^resources/(.+)\.rb$}) { |m| path_to_library_spec.call(m[1]) }
+  watch(%r{^resources/(.+)\.rb$}) { |m| "spec/unit/resources/#{m[1]}_spec.rb" }
+  watch(%r{^recipes/(.+)\.rb$}) { |m| "spec/unit/recipes/#{m[1]}_spec.rb" }
+
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,62 @@
+task(:default) { sh %( rake --tasks ) }
+
+namespace :test do
+  desc "Run Chef's code-style linter, cookstyle"
+  task :lint do
+    sh %( chef exec cookstyle )
+  end
+
+  desc "Run Chef's cookbook linter, foodcritic"
+  task :critic do
+    sh %( chef exec foodcritic . )
+  end
+
+  task foodcritic: [:critic]
+
+  desc "Run Chef's linter and attempt to auto-correct offenses"
+  task :lintfix do
+    sh %( chef exec cookstyle --auto-correct )
+  end
+
+  desc 'Run the unit tests'
+  task :unit do
+    sh %( chef exec rspec spec/ )
+  end
+
+  task spec: [:unit]
+
+  desc 'Spin up the kitchen instances for integration testing'
+  task :provision do
+    sh %( chef exec kitchen create )
+  end
+
+  desc 'Apply the cookbook to the running kitchen instances'
+  task :deploy do
+    sh %( chef exec kitchen converge )
+  end
+
+  desc 'Run the integration tests against already running kitchen instances'
+  task :verify do
+    sh %( chef exec kitchen verify )
+  end
+
+  desc 'Run the integration tests start to finish'
+  task :integration do
+    sh %( chef exec kitchen test )
+  end
+
+  desc 'Cleanup various artificats like lockfiles and running kitchen instances'
+  task :cleanup do
+    rm_rf ['Berksfile.lock', 'Gemfile.lock']
+    sh %( chef exec kitchen destroy )
+    rm_rf '.kitchen'
+  end
+
+  desc 'Run all tests in the following order: Lint => Critic => Unit => Integration'
+  task all: %i(lint critic unit integration)
+
+  desc 'Start `guard` for continuous testing'
+  task :guard do
+    sh %( bundle exec guard start )
+  end
+end

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,6 +3,7 @@
 - [Syntax and style](#syntax-and-style)
 - [Unit tests](#unit-tests)
 - [Integration tests](#integration-tests)
+- [Rake Tasks](#rake-tasks)
 
 ## Syntax and style
 
@@ -149,3 +150,11 @@ can take a while to run - some of our builds end up being 30-40 minutes per oper
 system. If you've got the hardware, don't be afraid to run
 `kitchen test --concurrency n` to save a little time (where `n` is the number of concurrent
 instances you want to boot up).
+
+## Rake Tasks
+
+Included are some convenient rake tasks for running particular batteries of tests. Just run `rake` to see a list of tasks available.
+
+### Continuous testing with guard
+
+We've included a Guardfile custom-tailored to run the appropriate unit tests whenever a file is modified. To get started, simply `bundle install && rake test:guard` and watch the appropriate tests run automatically as you edit source files!


### PR DESCRIPTION
Here's the list of rake tasks:
```
rake test:all          # Run all tests in the following order: Lint => Critic => Unit => Integration
rake test:cleanup      # Cleanup various artificats like lockfiles and running kitchen instances
rake test:critic       # Run Chef's cookbook linter, foodcritic
rake test:deploy       # Apply the cookbook to the running kitchen instances
rake test:guard        # Start `guard` for continuous testing
rake test:integration  # Run the integration tests start to finish
rake test:lint         # Run Chef's code-style linter, cookstyle
rake test:lintfix      # Run Chef's linter and attempt to auto-correct offenses
rake test:provision    # Spin up the kitchen instances for integration testing
rake test:unit         # Run the unit tests
rake test:verify       # Run the integration tests against already running kitchen instances
```

The Guardfile config is configured to run any library, recipe, or custom resource file's corresponding unit test(s) under `spec/unit/` whenever a file change is detected. Just run `bundle install && rake test:guard` to install the guard gem and start watching for changes.