### PR TITLE
Fix for Issue #107: User Deletion

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -115,6 +115,13 @@ suites:
     - admin-user
     - standard-user
 
+- name: delete_users
+  run_list:
+  - recipe[macos_test::delete_users]
+  verifier:
+    controls:
+    - test-user
+
 - name: keychain
   run_list:
   - recipe[macos_test::keychain]

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -119,8 +119,8 @@ action :delete do
     only_if { ::File.exist? user_home }
   end
 
-  execute "delete user: #{user}" do
-    command "#{sysadminctl} -deleteUser #{new_resource.username}"
+  execute "delete user: #{new_resource.username}" do
+    command [sysadminctl, '-deleteUser', new_resource.username]
     only_if { user_already_exists? }
   end
 end

--- a/test/cookbooks/macos_test/recipes/delete_users.rb
+++ b/test/cookbooks/macos_test/recipes/delete_users.rb
@@ -1,0 +1,17 @@
+user = 'test_user'
+user_home = File.join('/', 'Users', user)
+
+if Gem::Version.new(node['platform_version']) >= Gem::Version.new('10.13')
+  admin_credentials = ['-adminUser', node['macos']['admin_user'], '-adminPassword', node['macos']['admin_password']]
+else ''
+end
+
+execute "add user #{user}" do
+  command ['/usr/sbin/sysadminctl', *admin_credentials, '-addUser', user]
+  not_if { ::File.exist?(user_home) && user_already_exists? }
+end
+
+macos_user 'delete a given user' do
+  username user
+  action :delete
+end

--- a/test/integration/default/controls/users_and_groups_test.rb
+++ b/test/integration/default/controls/users_and_groups_test.rb
@@ -85,3 +85,12 @@ control 'standard-user' do
     its('stdout.split') { should_not include '80' }
   end
 end
+
+control 'test-user' do
+  title 'Checks that a user does not exist'
+  desc 'Given a previously added user, check that its deletion results in user no longer being in existence.'
+
+  describe user('test_user').exists? do
+    it { should eq false }
+  end
+end


### PR DESCRIPTION
## Bug Fix
The bug lies in the following: 

    execute "delete user: #{user}" do

`user` does not exist, so it was replaced with `new_resource.username`. 

## Other Changes

### Created a user deletion recipe and test suite
Recipe creates a user in an execute block with `sysadminctl` to avoid using macos_user (in case there are future issues in it), and also to simulate a previously existing user. 



