### PR TITLE
Release/2.3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -113,6 +113,7 @@ suites:
     controls:
     - admin-user
     - standard-user
+    - hidden-user
 
 - name: delete_users
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,6 @@ driver:
 
 provisioner:
   product_name: chef
-  install_strategy: always
 
 verifier:
   name: inspec
@@ -16,37 +15,37 @@ verifier:
 platforms:
 - name: el-capitan-chef13
   driver:
-    box: apex/macos-10.11.6
+    box: microsoft/os-x-el-capitan
   provisioner:
     product_version: 13
 
 - name: el-capitan-chef14
   driver:
-    box: apex/macos-10.11.6
+    box: microsoft/os-x-el-capitan
   provisioner:
     product_version: 14
 
 - name: sierra-chef13
   driver:
-    box: apex/macos-10.12.6
+    box: microsoft/macos-sierra
   provisioner:
     product_version: 13
 
 - name: sierra-chef14
   driver:
-    box: apex/macos-10.12.6
+    box: microsoft/macos-sierra
   provisioner:
     product_version: 14
 
 - name: high-sierra-chef13
   driver:
-    box: apex/macos-10.13.4
+    box: microsoft/macos-high-sierra
   provisioner:
     product_version: 13
 
 - name: high-sierra-chef14
   driver:
-    box: apex/macos-10.13.4
+    box: microsoft/macos-high-sierra
   provisioner:
     product_version: 14
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -114,6 +114,13 @@ suites:
     - admin-user
     - standard-user
 
+- name: delete_users
+  run_list:
+  - recipe[macos_test::delete_users]
+  verifier:
+    controls:
+    - test-user
+
 - name: keychain
   run_list:
   - recipe[macos_test::keychain]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default['macos']['admin_user'] = 'vagrant'
 default['macos']['admin_password'] = 'vagrant'
 
-default['macos']['xcode']['version'] = '9.3'
+default['macos']['xcode']['version'] = '9.4.1'
 
 default['macos']['remote_login_enabled'] = true
 

--- a/documentation/resource_macos_user.md
+++ b/documentation/resource_macos_user.md
@@ -17,6 +17,7 @@ macos_user 'user and action description' do
   password             String          # password for user, defaults to "password" if not specified
   autologin            TrueClass       # user autologin
   admin                TrueClass       # admin status of user
+  hidden               TrueClass       # hidden status of user
   fullname             String          # full name of user
   groups               Array, String   # list of groups the user is in
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.2.0'
+version '2.3.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -15,7 +15,7 @@ action :install do
   cert = SecurityCommand.new(new_resource.certfile, keychain)
 
   execute 'unlock keychain' do
-    command [*cert.unlock_keychain(node['macos']['admin_user'])]
+    command [*cert.unlock_keychain(node['macos']['admin_password'])]
   end
 
   execute 'install-certificate' do

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -119,8 +119,8 @@ action :delete do
     only_if { ::File.exist? user_home }
   end
 
-  execute "delete user: #{user}" do
-    command "#{sysadminctl} -deleteUser #{new_resource.username}"
+  execute "delete user: #{new_resource.username}" do
+    command [sysadminctl, '-deleteUser', new_resource.username]
     only_if { user_already_exists? }
   end
 end

--- a/test/cookbooks/macos_test/recipes/delete_users.rb
+++ b/test/cookbooks/macos_test/recipes/delete_users.rb
@@ -1,0 +1,17 @@
+user = 'test_user'
+user_home = File.join('/', 'Users', user)
+
+if Gem::Version.new(node['platform_version']) >= Gem::Version.new('10.13')
+  admin_credentials = ['-adminUser', node['macos']['admin_user'], '-adminPassword', node['macos']['admin_password']]
+else ''
+end
+
+execute "add user #{user}" do
+  command ['/usr/sbin/sysadminctl', *admin_credentials, '-addUser', user]
+  not_if { ::File.exist?(user_home) && user_already_exists? }
+end
+
+macos_user 'delete a given user' do
+  username user
+  action :delete
+end

--- a/test/cookbooks/macos_test/recipes/new_users.rb
+++ b/test/cookbooks/macos_test/recipes/new_users.rb
@@ -17,3 +17,9 @@ macos_user 'create non-admin without groups' do
   username 'paul'
   password 'bacon-saffron-doormat-educe'
 end
+
+macos_user 'create test' do
+  username 'griffin'
+  password 'wells'
+  hidden true
+end

--- a/test/cookbooks/macos_test/recipes/spotlight.rb
+++ b/test/cookbooks/macos_test/recipes/spotlight.rb
@@ -1,23 +1,13 @@
-if node['platform_version'].match?(/10.13/)
-  execute 'create test disk collection on APFS' do
-    command ['diskutil', 'apfs', 'resizeContainer',
-             'disk0s2', '25g',
-             'jhfs+', 'test_disk1', '1G',
-             'jhfs+', 'TDD2', '1G',
-             'jhfs+', 'Macintosh TD', '1G',
-             'jhfs+', 'TDD-ROM', '700MB']
-    not_if ['ls', '/Volumes/test_disk1']
-  end
+test_file = 'test.txt'
+test_volumes = ['test_disk1', 'TDD2', 'Macintosh TD', 'TDD-ROM']
 
-else
+file test_file
+test_volumes.each do |volume|
   execute 'create test disk collection on HFS' do
-    command ['diskutil', 'resizeVolume',
-             'disk0s2', '25g',
-             'jhfs+', 'test_disk1', '1G',
-             'jhfs+', 'TDD2', '1G',
-             'jhfs+', 'Macintosh TD', '1G',
-             'jhfs+', 'TDD-ROM', '700MB']
-    not_if ['ls', '/Volumes/test_disk1']
+    command ['hdiutil', 'create', "#{volume}.dmg",
+             '-size', '1g', '-format', 'UDRW',
+             '-volname', volume, '-srcfolder', test_file,
+             '-ov', '-attach']
   end
 end
 

--- a/test/cookbooks/macos_test/recipes/xcode_beta.rb
+++ b/test/cookbooks/macos_test/recipes/xcode_beta.rb
@@ -2,4 +2,4 @@ execute 'Disable Gatekeeper' do
   command ['spctl', '--master-disable']
 end
 
-xcode '9.4' if node['platform_version'].match? Regexp.union '10.13'
+xcode '10.0' if node['platform_version'].match? Regexp.union '10.13'

--- a/test/integration/default/controls/users_and_groups_test.rb
+++ b/test/integration/default/controls/users_and_groups_test.rb
@@ -85,3 +85,12 @@ control 'standard-user' do
     its('stdout.split') { should_not include '80' }
   end
 end
+
+control 'test-user' do
+  title 'Checks that a user does not exist'
+  desc 'Given a previously added user, check that its deletion results in user no longer being in existence.'
+
+  describe user('test_user').exists? do
+    it { should eq false }
+  end
+end

--- a/test/integration/default/controls/users_and_groups_test.rb
+++ b/test/integration/default/controls/users_and_groups_test.rb
@@ -86,6 +86,24 @@ control 'standard-user' do
   end
 end
 
+control 'hidden-user' do
+  title 'added as a hidden user'
+  desc 'Verify that a standard user is hidden'
+
+  describe user('griffin') do
+    it { should exist }
+    its('home') { should eq '/var/griffin' }
+  end
+
+  describe command("/usr/libexec/Plistbuddy -c 'Print IsHidden' /var/db/dslocal/nodes/Default/users/griffin.plist") do
+    its('stdout') { should match(/1/) }
+  end
+
+  describe directory('/var/griffin') do
+    it { should exist }
+  end
+end
+
 control 'test-user' do
   title 'Checks that a user does not exist'
   desc 'Given a previously added user, check that its deletion results in user no longer being in existence.'

--- a/test/integration/default/controls/xcode_test.rb
+++ b/test/integration/default/controls/xcode_test.rb
@@ -15,7 +15,7 @@ control 'xcode-and-simulators' do
   end
 
   if macos_version.match? Regexp.union '10.13'
-    describe directory('/Applications/Xcode-9.3.app') do
+    describe directory('/Applications/Xcode-9.4.1.app') do
       it { should exist }
     end
 
@@ -51,7 +51,7 @@ control 'xcode-beta' do
   macos_version = command('/usr/bin/sw_vers -productVersion').stdout.strip
 
   if macos_version.match? Regexp.union '10.13'
-    describe directory('/Applications/Xcode-9.4.app') do
+    describe directory('/Applications/Xcode-10.app') do
       it { should exist }
     end
   end


### PR DESCRIPTION
This releases adds a `hidden` property to the `macos_user` resource, and fixes a bug where deletion of a user was failing (thanks @mjmerin!). 

It also resolves a bug in the `certificate` resource for non-Vagrant use cases (thanks @MrChoclate!).

Finally, we've moved to a new set of internal Vagrant macOS boxes, which have a much more minimal initial configuration (thanks @americanhanko!), ensuring more of our resources work from an out-of-box macOS experience. 