### PR TITLE
Remove depends

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,11 +5,9 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.3.0'
+version '2.4.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'
 
 supports 'mac_os_x'
-
-depends 'homebrew'


### PR DESCRIPTION
Fix for issue #123

Removing the dependency on homebrew from metadata removes the warnings during builds. 