### PR TITLE
Fix for Issue #45: Spotlight resource does not verify metadata server is running

### DIFF
--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -3,23 +3,21 @@ include Chef::Mixin::ShellOut
 module MacOS
   class MetadataUtil
     attr_reader :status_flags
+    attr_reader :mdutil_output
 
     def initialize(volume)
       mdutil_possible_states = { 'Indexing enabled.' => ['on', ''],
                                  'Indexing disabled.' => ['off', ''],
-                                 'Indexing and searching disabled.' => ['off', '-d'],
-                                 'Spotlight server is disabled.' => %w(dis dis) }
+                                 'Indexing and searching disabled.' => ['off', '-d'] }
 
-      @status_flags = mdutil_possible_states[volume_current_state(volume)]
-                      .insert(1, volume)
+      @mdutil_output = shell_out('/usr/bin/mdutil', '-s', volume).stdout
+      @status_flags = unless server_disabled?
+                        mdutil_possible_states[volume_current_state(volume)].insert(1, volume)
+                      end
     end
 
-    def mdutil_output(volume)
-      shell_out('/usr/bin/mdutil', '-s', volume).stdout
-    end
-
-    def server_disabled?(volume)
-      status_flags == ['dis', volume, 'dis']
+    def server_disabled?
+      mdutil_output.strip.include? 'disabled'
     end
 
     def toggle_spotlight_server(flag)
@@ -27,9 +25,8 @@ module MacOS
       ['sudo', 'launchctl', action, '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
     end
 
-    def volume_current_state(volume)
-      output = mdutil_output(volume)
-      (output.include? ':') ? mdutil_output(volume).split(':')[1].strip : output.strip
+    def volume_current_state(_volume)
+      mdutil_output.split(':')[1].strip
     end
   end
 end

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -13,8 +13,12 @@ module MacOS
                       .insert(1, volume)
     end
 
+    def mdutil_output(volume)
+      shell_out('/usr/bin/mdutil', '-s', volume).stdout
+    end
+
     def volume_current_state(volume)
-      shell_out('/usr/bin/mdutil', '-s', volume).stdout.split(':')[1].strip
+      mdutil_output(volume).split(':')[1].strip
     end
   end
 end

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -7,7 +7,8 @@ module MacOS
     def initialize(volume)
       mdutil_possible_states = { 'Indexing enabled.' => ['on', ''],
                                  'Indexing disabled.' => ['off', ''],
-                                 'Indexing and searching disabled.' => ['off', '-d'] }
+                                 'Indexing and searching disabled.' => ['off', '-d'],
+                                 'Spotlight server is disabled.' => %w(dis dis) }
 
       @status_flags = mdutil_possible_states[volume_current_state(volume)]
                       .insert(1, volume)
@@ -17,8 +18,18 @@ module MacOS
       shell_out('/usr/bin/mdutil', '-s', volume).stdout
     end
 
+    def server_disabled?(volume)
+      status_flags == ['dis', volume, 'dis']
+    end
+
+    def toggle_spotlight_server(flag)
+      action = flag ? 'load' : 'unload'
+      ['sudo', 'launchctl', action, '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
+    end
+
     def volume_current_state(volume)
-      mdutil_output(volume).split(':')[1].strip
+      output = mdutil_output(volume)
+      (output.include? ':') ? mdutil_output(volume).split(':')[1].strip : output.strip
     end
   end
 end

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -32,8 +32,14 @@ action_class do
 end
 
 action :set do
+  volume = MetadataUtil.new(target_volume)
+
+  execute 'Enable Spotlight server' do
+    command volume.toggle_spotlight_server(true)
+    only_if { volume.server_disabled?(target_volume) }
+  end
+
   execute "turn Spotlight indexing #{state} for #{target_volume}" do
-    volume = MetadataUtil.new(target_volume)
     command mdutil + desired_spotlight_state.insert(0, '-i')
     not_if { volume.status_flags == desired_spotlight_state }
   end

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -36,7 +36,7 @@ action :set do
 
   execute 'Enable Spotlight server' do
     command volume.toggle_spotlight_server(true)
-    only_if { volume.server_disabled?(target_volume) }
+    only_if { volume.server_disabled? }
   end
 
   execute "turn Spotlight indexing #{state} for #{target_volume}" do

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -33,7 +33,8 @@ end
 
 action :set do
   execute "turn Spotlight indexing #{state} for #{target_volume}" do
+    volume = MetadataUtil.new(target_volume)
     command mdutil + desired_spotlight_state.insert(0, '-i')
-    not_if { MetadataUtil.new(target_volume).status_flags == desired_spotlight_state }
+    not_if { volume.status_flags == desired_spotlight_state }
   end
 end

--- a/spec/unit/libraries/metadata_util_spec.rb
+++ b/spec/unit/libraries/metadata_util_spec.rb
@@ -56,4 +56,15 @@ describe MacOS::MetadataUtil do
       expect(md.status_flags).to eq ['off', '/Volumes/TDD-ROM', '-d']
     end
   end
+
+  context 'when the Spotlight server is disabled' do
+    before do
+      allow_any_instance_of(MacOS::MetadataUtil).to receive(:volume_current_state)
+        .and_return('Spotlight server is disabled.')
+    end
+    it 'returns an array containing the mdutil flags matching that state' do
+      md = MacOS::MetadataUtil.new('/')
+      expect(md.status_flags).to eq ['dis', '/', 'dis']
+    end
+  end
 end

--- a/spec/unit/libraries/metadata_util_spec.rb
+++ b/spec/unit/libraries/metadata_util_spec.rb
@@ -56,15 +56,4 @@ describe MacOS::MetadataUtil do
       expect(md.status_flags).to eq ['off', '/Volumes/TDD-ROM', '-d']
     end
   end
-
-  context 'when the Spotlight server is disabled' do
-    before do
-      allow_any_instance_of(MacOS::MetadataUtil).to receive(:volume_current_state)
-        .and_return('Spotlight server is disabled.')
-    end
-    it 'returns an array containing the mdutil flags matching that state' do
-      md = MacOS::MetadataUtil.new('/')
-      expect(md.status_flags).to eq ['dis', '/', 'dis']
-    end
-  end
 end

--- a/test/cookbooks/macos_test/recipes/spotlight.rb
+++ b/test/cookbooks/macos_test/recipes/spotlight.rb
@@ -11,6 +11,10 @@ test_volumes.each do |volume|
   end
 end
 
+execute 'test' do
+  command ['sudo', 'launchctl', 'unload', '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
+end
+
 spotlight '/'
 
 spotlight 'test_disk1' do


### PR DESCRIPTION
- Support an additional status_flag for `mdutil_possible_states`
- Primarily focused in putting additional logic in the `metadata_util` library which now allows checking for server up/down status and for toggling. 
- Add unit test to check for new status flag
- Update integration test to actually turn off the Spotlight Server at the very start of the recipe

