### PR TITLE
Release/2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [2.4.0] - 2018-08-15
+## [2.4.0] - 2018-08-16
 ### Added
 - Added `CHANGELOG.md`. ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Resources
 
 - [ARD (Apple Remote Desktop)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_ard.md)
 - [Certificate (security)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_certificate.md)
-- [Keychain (security)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/keychain_certificate.md)
+- [Keychain (security)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_keychain.md)
 - [Machine Name](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_machine_name.md)
 - [macOS User (sysadminctl)](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_macos_user.md)
 - [Plist](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_plist.md)

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -3,18 +3,30 @@ include Chef::Mixin::ShellOut
 module MacOS
   class MetadataUtil
     attr_reader :status_flags
+    attr_reader :mdutil_output
 
     def initialize(volume)
       mdutil_possible_states = { 'Indexing enabled.' => ['on', ''],
                                  'Indexing disabled.' => ['off', ''],
                                  'Indexing and searching disabled.' => ['off', '-d'] }
 
-      @status_flags = mdutil_possible_states[volume_current_state(volume)]
-                      .insert(1, volume)
+      @mdutil_output = shell_out('/usr/bin/mdutil', '-s', volume).stdout
+      @status_flags = unless server_disabled?
+                        mdutil_possible_states[volume_current_state(volume)].insert(1, volume)
+                      end
     end
 
-    def volume_current_state(volume)
-      shell_out('/usr/bin/mdutil', '-s', volume).stdout.split(':')[1].strip
+    def server_disabled?
+      mdutil_output.strip.include? 'disabled'
+    end
+
+    def toggle_spotlight_server(flag)
+      action = flag ? 'load' : 'unload'
+      ['sudo', 'launchctl', action, '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
+    end
+
+    def volume_current_state(_volume)
+      mdutil_output.split(':')[1].strip
     end
   end
 end

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -20,11 +20,6 @@ module MacOS
       mdutil_output.strip.include? 'disabled'
     end
 
-    def toggle_spotlight_server(flag)
-      action = flag ? 'load' : 'unload'
-      ['sudo', 'launchctl', action, '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
-    end
-
     def volume_current_state(_volume)
       mdutil_output.split(':')[1].strip
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.3.0'
+version '2.4.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,3 @@ source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'
 
 supports 'mac_os_x'
-
-depends 'homebrew'

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -32,8 +32,15 @@ action_class do
 end
 
 action :set do
+  volume = MetadataUtil.new(target_volume)
+
+  execute 'Enable Spotlight server' do
+    command volume.toggle_spotlight_server(true)
+    only_if { volume.server_disabled? }
+  end
+
   execute "turn Spotlight indexing #{state} for #{target_volume}" do
     command mdutil + desired_spotlight_state.insert(0, '-i')
-    not_if { MetadataUtil.new(target_volume).status_flags == desired_spotlight_state }
+    not_if { volume.status_flags == desired_spotlight_state }
   end
 end

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -34,9 +34,10 @@ end
 action :set do
   volume = MetadataUtil.new(target_volume)
 
-  execute 'Enable Spotlight server' do
-    command volume.toggle_spotlight_server(true)
-    only_if { volume.server_disabled? }
+  service 'spotlight server' do
+    service_name 'mds'
+    plist '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist'
+    action [:enable, :start]
   end
 
   execute "turn Spotlight indexing #{state} for #{target_volume}" do

--- a/test/cookbooks/macos_test/recipes/spotlight.rb
+++ b/test/cookbooks/macos_test/recipes/spotlight.rb
@@ -11,6 +11,10 @@ test_volumes.each do |volume|
   end
 end
 
+execute 'test' do
+  command ['sudo', 'launchctl', 'unload', '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
+end
+
 spotlight '/'
 
 spotlight 'test_disk1' do


### PR DESCRIPTION
## [2.4.0] - 2018-08-16
### Added
- Added `CHANGELOG.md`. ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).
 ### Removed
- `homebrew` cookbook dependency removed. `homebrew_cask` and `homebrew_tap` is being deprecated by Chef and has not been used by `macos-cookbook` since version `2.0`. ([Issue #123](https://github.com/Microsoft/macos-cookbook/issues/123)).
 ### Fixed
- Fixed `keychain` resource documentation link.
- Update `metadata_util` library to consider Spotlight server status before manipulating indexing state. ([Issue #45](https://github.com/Microsoft/macos-cookbook/issues/45)).