### PR TITLE
Use macosx_service for spotlight server on/off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [2.4.0] - 2018-08-15
+## [2.4.0] - 2018-08-16
 ### Added
 - Added `CHANGELOG.md`. ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).
 

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -20,11 +20,6 @@ module MacOS
       mdutil_output.strip.include? 'disabled'
     end
 
-    def toggle_spotlight_server(flag)
-      action = flag ? 'load' : 'unload'
-      ['sudo', 'launchctl', action, '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
-    end
-
     def volume_current_state(_volume)
       mdutil_output.split(':')[1].strip
     end

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -34,7 +34,7 @@ end
 action :set do
   volume = MetadataUtil.new(target_volume)
 
-  macosx_service 'spotlight server' do
+  service 'spotlight server' do
     service_name 'mds'
     plist '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist'
     action [:enable, :start]

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -34,9 +34,10 @@ end
 action :set do
   volume = MetadataUtil.new(target_volume)
 
-  execute 'Enable Spotlight server' do
-    command volume.toggle_spotlight_server(true)
-    only_if { volume.server_disabled? }
+  macosx_service 'spotlight server' do
+    service_name 'mds'
+    plist '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist'
+    action [:enable, :start]
   end
 
   execute "turn Spotlight indexing #{state} for #{target_volume}" do


### PR DESCRIPTION
Responding to @americanhanko  review point, the use of the macosx_service resource guarantees idempotentiality and has allowed the removal of routines that directly call the launchctl command. 