### PR TITLE
Add an attribute to manage VNC screen lock setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.4.1] - 2018-08-29
+### Fixed
+- Resolves an issue where disconnecting from a VNC session in Apple Remote Desktop would trigger a screen lock. This issue is actual a preference,
+which is now managed with a new attribute: `node['macos']['vnc_screen_lock_enabled']`
+
 ## [2.4.0] - 2018-08-16
 ### Added
 - Added `CHANGELOG.md`. ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).

--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ to always keep macOS on and available.
 
 **Usage:** `include_recipe 'macos::keep_awake'`
 
-| Attributes used                         | Default value           |
-|-----------------------------------------|-------------------------|
-| `node['macos']['remote_login_enabled']` | `true`                  |
-| `node['macos']['network_time_server']`  | `'time.windows.com'`    |
-| `node['macos']['time_zone']`            | `'America/Los_Angeles'` |
+| Attributes used                            | Default value           |
+|--------------------------------------------|-------------------------|
+| `node['macos']['remote_login_enabled']`    | `true`                  |
+| `node['macos']['disable_vnc_screen_lock']` | `false`                 |
+| `node['macos']['network_time_server']`     | `'time.windows.com'`    |
+| `node['macos']['time_zone']`               | `'America/Los_Angeles'` |
+
+:warning: Disabling VNC screen lock could be considered a security risk at some organizations. Use with caution.
 
 ### Xcode
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to always keep macOS on and available.
 | Attributes used                            | Default value           |
 |--------------------------------------------|-------------------------|
 | `node['macos']['remote_login_enabled']`    | `true`                  |
-| `node['macos']['disable_vnc_screen_lock']` | `false`                 |
+| `node['macos']['vnc_screen_lock_enabled']` | `true`                  |
 | `node['macos']['network_time_server']`     | `'time.windows.com'`    |
 | `node['macos']['time_zone']`               | `'America/Los_Angeles'` |
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default['macos']['admin_password'] = 'vagrant'
 default['macos']['xcode']['version'] = '9.4.1'
 
 default['macos']['remote_login_enabled'] = true
-default['macos']['disable_vnc_screen_lock'] = false
+default['macos']['vnc_screen_lock_enabled'] = true
 
 default['macos']['network_time_server'] = 'time.windows.com'
 default['macos']['time_zone'] = 'America/Los_Angeles'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,7 @@ default['macos']['admin_password'] = 'vagrant'
 default['macos']['xcode']['version'] = '9.4.1'
 
 default['macos']['remote_login_enabled'] = true
+default['macos']['disable_vnc_screen_lock'] = false
 
 default['macos']['network_time_server'] = 'time.windows.com'
 default['macos']['time_zone'] = 'America/Los_Angeles'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.4.0'
+version '2.4.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/recipes/keep_awake.rb
+++ b/recipes/keep_awake.rb
@@ -73,5 +73,5 @@ end
 
 defaults 'disable VNC screen lock' do
   domain '/Library/Preferences/com.apple.RemoteManagement'
-  settings 'RestoreMachineState' => node['macos']['disable_vnc_screen_lock']
+  settings 'RestoreMachineState' => node['macos']['vnc_screen_lock_enabled']
 end

--- a/recipes/keep_awake.rb
+++ b/recipes/keep_awake.rb
@@ -70,3 +70,8 @@ defaults 'com.apple.screensaver' do
   not_if { screensaver.disabled? }
   user node['macos']['admin_user']
 end
+
+defaults 'disable VNC screen lock' do
+  domain '/Library/Preferences/com.apple.RemoteManagement'
+  settings 'RestoreMachineState' => node['macos']['disable_vnc_screen_lock']
+end

--- a/recipes/keep_awake.rb
+++ b/recipes/keep_awake.rb
@@ -73,5 +73,5 @@ end
 
 defaults 'disable VNC screen lock' do
   domain '/Library/Preferences/com.apple.RemoteManagement'
-  settings 'RestoreMachineState' => node['macos']['vnc_screen_lock_enabled']
+  settings 'RestoreMachineState' => !node['macos']['vnc_screen_lock_enabled']
 end


### PR DESCRIPTION
## This PR

Adds a new attribute to manage the VNC screen lock setting

## Why

When using Apple Remote Desktop to control computers, disconnecting from a machine will automatically bring it into a 'sleep' state - this causes the screen to lock automatically given the screen lock setting in System Preferences -> Security & Privacy, which is sometimes a hindrance when needing to observe the state of the machine regularly.
