### PR TITLE
Implement 'path' property for Xcode

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -106,7 +106,7 @@ suites:
   - recipe[macos_test::xcode_beta]
   verifier:
     controls:
-    - xcode-beta
+    - xcode-and-simulators
 
 - name: certificate
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -107,6 +107,11 @@ suites:
   verifier:
     controls:
     - xcode-and-simulators
+  excludes:
+    - el-capitan-chef13
+    - el-capitan-chef14
+    - sierra-chef13
+    - sierra-chef14
 
 - name: certificate
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -107,11 +107,6 @@ suites:
   verifier:
     controls:
     - xcode-beta
-  excludes:
-    - el-capitan-chef13
-    - el-capitan-chef14
-    - sierra-chef13
-    - sierra-chef14
 
 - name: certificate
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -106,7 +106,7 @@ suites:
   - recipe[macos_test::xcode_beta]
   verifier:
     controls:
-    - xcode-and-simulators
+    - xcode-beta
   excludes:
     - el-capitan-chef13
     - el-capitan-chef14

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -5,19 +5,23 @@ module MacOS
     attr_reader :version
 
     def initialize
+      install_sentinel = '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+      FileUtils.touch install_sentinel
+      FileUtils.chown 'root', 'wheel', install_sentinel
+
       @version = if available_command_line_tools.empty?
-                   'none'
+                   'Unavailable from Software Update Catalog'
                  else
                    available_command_line_tools.last.tr('*', '').strip
                  end
     end
 
     def available_command_line_tools
-      available_products.lines.select { |s| s.include?('* Command') }
+      softwareupdate_list.select { |product_name| product_name.include?('* Command Line Tools') }
     end
 
-    def available_products
-      shell_out(['softwareupdate', '--list']).stdout
+    def softwareupdate_list
+      shell_out(['softwareupdate', '--list']).stdout.lines
     end
 
     def installed?

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -2,10 +2,10 @@ include Chef::Mixin::ShellOut
 
 module MacOS
   class CommandLineTools
-    attr_reader :product
+    attr_reader :version
 
     def initialize
-      @product = if available_command_line_tools.empty?
+      @version = if available_command_line_tools.empty?
                    'none'
                  else
                    available_command_line_tools.last.tr('*', '').strip
@@ -18,6 +18,10 @@ module MacOS
 
     def available_products
       shell_out(['softwareupdate', '--list']).stdout
+    end
+
+    def installed?
+      ::File.exist?('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
     end
   end
 end

--- a/libraries/developer_account.rb
+++ b/libraries/developer_account.rb
@@ -1,0 +1,33 @@
+include Chef::Mixin::ShellOut
+include MacOS::XCVersion
+
+module MacOS
+  class DeveloperAccount
+    attr_reader :credentials
+
+    def initialize(data_bag_retrieval = nil, node_credential_attributes = nil)
+      developer_id = find_apple_id(data_bag_retrieval, node_credential_attributes)
+      @credentials = { XCODE_INSTALL_USER:     developer_id['apple_id'],
+                       XCODE_INSTALL_PASSWORD: developer_id['password'] }
+      authenticate_with_apple(@credentials)
+    end
+
+    def authenticate_with_apple(credentials)
+      shell_out!(XCVersion.update, env: credentials)
+    end
+
+    def find_apple_id(data_bag_retrieval, node_credential_attributes)
+      if node_credential_attributes
+        { 'apple_id' => node_credential_attributes['user'],
+          'password' => node_credential_attributes['password'] }
+      else
+        data_bag_retrieval.call
+      end
+    rescue Net::HTTPServerException
+      Chef::Application.fatal!('No developer credentials supplied!')
+    end
+  end
+end
+
+Chef::Recipe.include(MacOS)
+Chef::Resource.include(MacOS)

--- a/libraries/developer_account.rb
+++ b/libraries/developer_account.rb
@@ -1,5 +1,5 @@
 include Chef::Mixin::ShellOut
-include MacOS::XCVersion
+include MacOS
 
 module MacOS
   class DeveloperAccount

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -29,18 +29,18 @@ module MacOS
       available_versions_list.map { |v| Xcode::Version.new v.split.first }
     end
 
-    def path_hash
+    def version_path_map
       xcversion_output = shell_out(XCVersion.installed_xcodes).stdout.lines
       xcode_paths = xcversion_output.map { |line| { line.split.first => line.split.last.delete('()') } }
       xcode_paths.find { |path| path[@semantic_version] }
     end
 
     def path
-      path_hash[@semantic_version]
+      version_path_map[@semantic_version]
     end
 
     def installed?
-      path_hash.any?
+      version_path_map.any?
     end
 
     def authenticate_with_apple(credentials)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -29,18 +29,23 @@ module MacOS
       available_versions_list.map { |v| Xcode::Version.new v.split.first }
     end
 
-    def version_path_map
-      xcversion_output = shell_out(XCVersion.installed_xcodes).stdout.lines
-      xcode_paths = xcversion_output.map { |line| { line.split.first => line.split.last.delete('()') } }
+    def installed_xcodes
+      shell_out(XCVersion.installed_xcodes).stdout.lines
+    end
+
+    def version_path
+      xcode_paths = installed_xcodes.map { |line| { line.split.first => line.split.last.delete('()') } }
       xcode_paths.find { |path| path[@semantic_version] }
     end
 
     def path
-      version_path_map[@semantic_version]
+      return "/Applications/Xcode-#{@apple_version}.app" if version_path.nil?
+      version_path[@semantic_version]
     end
 
     def installed?
-      version_path_map.any?
+      return false if version_path.nil?
+      version_path.any?
     end
 
     def authenticate_with_apple(credentials)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,7 +1,5 @@
-require_relative '../libraries/xcversion'
-
 include Chef::Mixin::ShellOut
-include MacOS::XCVersion
+include MacOS
 
 module MacOS
   class Xcode

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,66 +1,41 @@
+require_relative '../libraries/xcversion'
+
 include Chef::Mixin::ShellOut
+include MacOS::XCVersion
 
 module MacOS
   class Xcode
     attr_reader :version
-    attr_reader :credentials
     attr_reader :apple_version
+    attr_reader :intended_path
 
-    def initialize(semantic_version, data_bag_retrieval = nil, node_credential_attributes = nil)
-      developer_id = find_apple_id(data_bag_retrieval, node_credential_attributes)
-      @credentials = { XCODE_INSTALL_USER:     developer_id['apple_id'],
-                       XCODE_INSTALL_PASSWORD: developer_id['password'] }
-      authenticate_with_apple(@credentials)
-
+    def initialize(semantic_version, intended_path)
       @semantic_version = semantic_version
+      @intended_path = intended_path
       @apple_version = Xcode::Version.new(@semantic_version).apple
-      @version = available_versions_list[xcode_index(@apple_version)].strip
+      @version = XCVersion.available_versions[xcode_index(@apple_version)].strip
     end
 
     def xcode_index(version)
       available_xcodes.index { |available_version| available_version.apple == version }
     end
 
-    def available_versions_list
-      shell_out!(XCVersion.list_xcodes).stdout.lines
-    end
-
     def available_xcodes
-      available_versions_list.map { |v| Xcode::Version.new v.split.first }
+      XCVersion.available_versions.map { |v| Xcode::Version.new v.split.first }
     end
 
-    def installed_xcodes
-      shell_out(XCVersion.installed_xcodes).stdout.lines
+    def installed_path
+      XCVersion.installed_xcodes.find { |path| path[@semantic_version] }
     end
 
-    def version_path
-      xcode_paths = installed_xcodes.map { |line| { line.split.first => line.split.last.delete('()') } }
-      xcode_paths.find { |path| path[@semantic_version] }
-    end
-
-    def path
-      return "/Applications/Xcode-#{@apple_version}.app" if version_path.nil?
-      version_path[@semantic_version]
+    def current_path
+      return "/Applications/Xcode-#{@apple_version}.app" if installed_path.nil?
+      installed_path[@semantic_version]
     end
 
     def installed?
-      return false if version_path.nil?
-      version_path.any?
-    end
-
-    def authenticate_with_apple(credentials)
-      shell_out!(XCVersion.update, env: credentials)
-    end
-
-    def find_apple_id(data_bag_retrieval, node_credential_attributes)
-      if node_credential_attributes
-        { 'apple_id' => node_credential_attributes['user'],
-          'password' => node_credential_attributes['password'] }
-      else
-        data_bag_retrieval.call
-      end
-    rescue Net::HTTPServerException
-      Chef::Application.fatal!('No developer credentials supplied!')
+      return false if installed_path.nil?
+      installed_path.any?
     end
 
     class Simulator

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -28,7 +28,12 @@ module MacOS
       end
 
       def installed_xcodes
-        xcversion + 'installed'
+        lines = shell_out(xcversion + 'installed').stdout.lines
+        lines.map { |line| { line.split.first => line.split.last.delete('()') } }
+      end
+
+      def available_versions
+        shell_out!(XCVersion.list_xcodes).stdout.lines
       end
     end
   end

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -1,15 +1,17 @@
 resource_name :xcode
-default_action %i(setup install_xcode install_simulators)
+default_action %i(install_gem install_xcode install_simulators)
 
 property :version, String, name_property: true
 property :path, String, default: '/Applications/Xcode.app'
 property :ios_simulators, Array
 
-action :setup do
+action :install_gem do
+  command_line_tools = CommandLineTools.new
+
   execute 'install Command Line Tools' do
-    command lazy { ['softwareupdate', '--install', CommandLineTools.new.product] }
+    command lazy { ['softwareupdate', '--install', command_line_tools.version] }
     notifies :create, 'file[sentinel to request on-demand install]', :before
-    not_if { ::File.exist?('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib') }
+    not_if { command_line_tools.installed? }
     live_stream true
   end
 

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -35,6 +35,21 @@ action :install_xcode do
     not_if { xcode.installed? }
     timeout 7200
   end
+
+  link 'delete symlink created by xcversion gem' do
+    target_file '/Applications/Xcode.app'
+    action :delete
+    only_if 'test -L /Applications/Xcode.app'
+  end
+
+  execute "move #{xcode.path} to #{new_resource.path}" do
+    command ['mv', xcode.path, new_resource.path]
+    not_if { xcode.path == new_resource.path }
+  end
+
+  execute "switch active Xcode to #{new_resource.path}" do
+    command ['xcode-select', '--switch', new_resource.path]
+  end
 end
 
 action :install_simulators do

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -18,6 +18,8 @@ action :install_gem do
   file 'sentinel to request on-demand install' do
     path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
     subscribes :delete, 'execute[install Command Line Tools]', :immediately
+    owner 'root'
+    group 'wheel'
     action :nothing
   end
 

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -8,19 +8,10 @@ property :ios_simulators, Array
 action :install_gem do
   command_line_tools = CommandLineTools.new
 
-  execute 'install Command Line Tools' do
-    command lazy { ['softwareupdate', '--install', command_line_tools.version] }
-    notifies :create, 'file[sentinel to request on-demand install]', :before
+  execute "install #{command_line_tools.version}" do
+    command ['softwareupdate', '--install', command_line_tools.version]
     not_if { command_line_tools.installed? }
     live_stream true
-  end
-
-  file 'sentinel to request on-demand install' do
-    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
-    subscribes :delete, 'execute[install Command Line Tools]', :immediately
-    owner 'root'
-    group 'wheel'
-    action :nothing
   end
 
   chef_gem 'xcode-install' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require_relative '../libraries/plist'
 require_relative '../libraries/system'
 require_relative '../libraries/xcode'
 require_relative '../libraries/xcversion'
+require_relative '../libraries/developer_account'
 require_relative '../libraries/command_line_tools'
 require_relative '../libraries/security_cmd'
 

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -4,16 +4,16 @@ include MacOS
 describe MacOS::CommandLineTools do
   context 'when provided an available list of software update products' do
     before do
-      allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_products)
-        .and_return(<<~SOFTWAREUPDATE_LIST
-                    Software Update Tool
-                    Finding available software
-                    Software Update found the following new or updated software:
-                       * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2
-                    \tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]
-                       * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2
-                    \tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.2), 177376K [recommended]
-                    SOFTWAREUPDATE_LIST
+      allow(FileUtils).to receive(:touch).and_return(true)
+      allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                     "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.2), 177376K [recommended]\n"]
                    )
     end
     it 'returns the latest recommended Command Line Tools product' do

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -18,7 +18,7 @@ describe MacOS::CommandLineTools do
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
-      expect(clt.product).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2'
+      expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2'
     end
   end
 end

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -4,11 +4,7 @@ include MacOS
 describe MacOS::Xcode do
   context 'when initialized with developer credentials and Xcode betas available' do
     before do
-      allow_any_instance_of(MacOS::Xcode).to receive(:authenticate_with_apple)
-        .and_return(true)
-      allow_any_instance_of(MacOS::Xcode).to receive(:find_apple_id)
-        .and_return('apple_id': 'apple_id', 'password': 'password')
-      allow_any_instance_of(MacOS::Xcode).to receive(:available_versions_list)
+      allow(MacOS::XCVersion).to receive(:available_versions)
         .and_return(["4.3 for Lion\n",
                      "4.3.1 for Lion\n",
                      "4.3.2 for Lion\n",
@@ -56,28 +52,30 @@ describe MacOS::Xcode do
                      "9.1\n",
                      "9.2\n",
                      "9.3\n",
-                     "9.4 beta\n",
+                     "9.4\n",
+                     "9.4.1\n",
+                     "9.4.2 beta\n",
                      "10 GM seed\n"]
                    )
     end
     it 'returns the name of Xcode 10 GM when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('10.0')
+      xcode = MacOS::Xcode.new('10.0', '/Applications/Xcode.app')
       expect(xcode.version).to eq '10 GM seed'
     end
     it 'returns the name of Xcode 9.4 beta when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('9.4')
-      expect(xcode.version).to eq '9.4 beta'
+      xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
+      expect(xcode.version).to eq '9.4.2 beta'
     end
     it 'returns the name of Xcode 9.3 when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('9.3')
+      xcode = MacOS::Xcode.new('9.3', '/Applications/Xcode.app')
       expect(xcode.version).to eq '9.3'
     end
     it 'returns the name of Xcode 9 when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('9.0')
+      xcode = MacOS::Xcode.new('9.0', '/Applications/Xcode.app')
       expect(xcode.version).to eq '9'
     end
     it 'returns the name of Xcode 8.3.3 when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('8.3.3')
+      xcode = MacOS::Xcode.new('8.3.3', '/Applications/Xcode.app')
       expect(xcode.version).to eq '8.3.3'
     end
   end

--- a/spec/unit/recipes/disable_software_updates_spec.rb
+++ b/spec/unit/recipes/disable_software_updates_spec.rb
@@ -5,6 +5,8 @@ describe 'macos::disable_software_updates' do
     let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
     it 'converges successfully' do
+      allow_any_instance_of(MacOS::SoftwareUpdates).to receive(:automatic_check_disabled?)
+        .and_return(false)
       expect { chef_run }.to_not raise_error
     end
   end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -68,6 +68,8 @@ describe 'xcode' do
                    "10 GM seed\n"]
                  )
     allow(File).to receive(:exist?).and_call_original
+    allow(FileUtils).to receive(:touch).and_return(true)
+    allow(FileUtils).to receive(:chown).and_return(true)
   end
 
   context 'with no Xcodes installed, and no CLT installed' do
@@ -83,12 +85,7 @@ describe 'xcode' do
       xcode '9.4.1'
     end
 
-    it {
-      expect(chef_run.execute('install Command Line Tools'))
-        .to notify('file[sentinel to request on-demand install]')
-        .to(:create).before
-    }
-    it { is_expected.to run_execute('install Command Line Tools') }
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
 
     it { is_expected.to run_execute('install Xcode 9.4.1') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
@@ -110,8 +107,7 @@ describe 'xcode' do
       xcode '9.4.1'
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools') }
-    it { is_expected.not_to render_file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
 
     it { is_expected.to run_execute('install Xcode 9.4.1') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
@@ -133,8 +129,7 @@ describe 'xcode' do
       xcode '9.4.1'
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools') }
-    it { is_expected.not_to render_file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
 
     it { is_expected.not_to run_execute('install Xcode 9.4.1') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
@@ -158,8 +153,7 @@ describe 'xcode' do
       end
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools') }
-    it { is_expected.not_to render_file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
 
     it { is_expected.not_to run_execute('install Xcode 9.4.1') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
@@ -183,12 +177,7 @@ describe 'xcode' do
       end
     end
 
-    it {
-      expect(chef_run.execute('install Command Line Tools'))
-        .to notify('file[sentinel to request on-demand install]')
-        .to(:create).before
-    }
-    it { is_expected.to run_execute('install Command Line Tools') }
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
 
     it { is_expected.to run_execute('install Xcode 9.4.1') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -8,13 +8,13 @@ describe 'xcode' do
   default_attributes['macos']['apple_id']['password'] = 'apple_id_password'
 
   before(:each) do
-    allow_any_instance_of(MacOS::Xcode).to receive(:authenticate_with_apple)
+    allow_any_instance_of(MacOS::DeveloperAccount).to receive(:authenticate_with_apple)
       .and_return(true)
     allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_command_line_tools)
       .and_return(["   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
                    "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
                    "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n"])
-    allow_any_instance_of(MacOS::Xcode).to receive(:available_versions_list)
+    allow(MacOS::XCVersion).to receive(:available_versions)
       .and_return(["4.3 for Lion\n",
                    "4.3.1 for Lion\n",
                    "4.3.2 for Lion\n",
@@ -64,6 +64,7 @@ describe 'xcode' do
                    "9.3\n",
                    "9.4\n",
                    "9.4.1\n",
+                   "9.4.2 beta\n",
                    "10 GM seed\n"]
                  )
     allow(File).to receive(:exist?).and_call_original
@@ -71,7 +72,7 @@ describe 'xcode' do
 
   context 'with no Xcodes installed, and no CLT installed' do
     before(:each) do
-      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
         .and_return([])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(false)
@@ -98,7 +99,7 @@ describe 'xcode' do
 
   context 'with no Xcodes installed, and with CLT installed' do
     before(:each) do
-      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
         .and_return([])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(true)
@@ -121,8 +122,8 @@ describe 'xcode' do
 
   context 'with requested Xcode installed, and with CLT installed' do
     before(:each) do
-      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
-        .and_return(["9.4.1\t(/Applications/Xcode.app)\t\n"])
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([{ '9.4.1' => '/Applications/Xcode.app' }])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
@@ -144,8 +145,8 @@ describe 'xcode' do
 
   context 'with requested Xcode installed at a different path, and with CLT present' do
     before(:each) do
-      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
-        .and_return(["9.4.1\t(/Applications/Some_Weird_Path.app)\t\n"])
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([{ '9.4.1' => '/Applications/Some_Weird_Path.app' }])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
@@ -169,8 +170,8 @@ describe 'xcode' do
 
   context 'with requested Xcode version not installed, and something at the requested path' do
     before(:each) do
-      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
-        .and_return(["9.3\t(/Applications/Xcode.app)\t\n"])
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([{ '9.3' => '/Applications/Xcode.app' }])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(false)
       stub_command('test -L /Applications/Xcode.app').and_return(true)

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -1,0 +1,198 @@
+require 'spec_helper'
+
+describe 'xcode' do
+  step_into :xcode
+  platform 'mac_os_x'
+
+  default_attributes['macos']['apple_id']['user'] = 'developer@apple.com'
+  default_attributes['macos']['apple_id']['password'] = 'apple_id_password'
+
+  before(:each) do
+    allow_any_instance_of(MacOS::Xcode).to receive(:authenticate_with_apple)
+      .and_return(true)
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_command_line_tools)
+      .and_return(["   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n"])
+    allow_any_instance_of(MacOS::Xcode).to receive(:available_versions_list)
+      .and_return(["4.3 for Lion\n",
+                   "4.3.1 for Lion\n",
+                   "4.3.2 for Lion\n",
+                   "4.3.3 for Lion\n",
+                   "4.4\n",
+                   "4.4.1\n",
+                   "4.5\n",
+                   "4.5.1\n",
+                   "4.5.2\n",
+                   "4.6\n",
+                   "4.6.1\n",
+                   "4.6.2\n",
+                   "4.6.3\n",
+                   "5\n",
+                   "5.0.1\n",
+                   "5.0.2\n",
+                   "5.1\n",
+                   "5.1.1\n",
+                   "6.0.1\n",
+                   "6.1\n",
+                   "6.1.1\n",
+                   "6.2\n",
+                   "6.3\n",
+                   "6.3.1\n",
+                   "6.3.2\n",
+                   "6.4\n",
+                   "7\n",
+                   "7.0.1\n",
+                   "7.1\n",
+                   "7.1.1\n",
+                   "7.2\n",
+                   "7.2.1\n",
+                   "7.3\n",
+                   "7.3.1\n",
+                   "8\n",
+                   "8.1\n",
+                   "8.2\n",
+                   "8.2.1\n",
+                   "8.3\n",
+                   "8.3.1\n",
+                   "8.3.2\n",
+                   "8.3.3\n",
+                   "9\n",
+                   "9.0.1\n",
+                   "9.1\n",
+                   "9.2\n",
+                   "9.3\n",
+                   "9.4\n",
+                   "9.4.1\n",
+                   "10 GM seed\n"]
+                 )
+    allow(File).to receive(:exist?).and_call_original
+  end
+
+  context 'with no Xcodes installed, and no CLT installed' do
+    before(:each) do
+      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
+        .and_return([])
+      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
+                                     .and_return(false)
+      stub_command('test -L /Applications/Xcode.app').and_return(true)
+    end
+
+    recipe do
+      xcode '9.4.1'
+    end
+
+    it {
+      expect(chef_run.execute('install Command Line Tools'))
+        .to notify('file[sentinel to request on-demand install]')
+        .to(:create).before
+    }
+    it { is_expected.to run_execute('install Command Line Tools') }
+
+    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+
+  context 'with no Xcodes installed, and with CLT installed' do
+    before(:each) do
+      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
+        .and_return([])
+      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
+                                     .and_return(true)
+      stub_command('test -L /Applications/Xcode.app').and_return(true)
+    end
+
+    recipe do
+      xcode '9.4.1'
+    end
+
+    it { is_expected.not_to run_execute('install Command Line Tools') }
+    it { is_expected.not_to render_file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') }
+
+    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+
+  context 'with requested Xcode installed, and with CLT installed' do
+    before(:each) do
+      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
+        .and_return(["9.4.1\t(/Applications/Xcode.app)\t\n"])
+      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
+                                     .and_return(true)
+      stub_command('test -L /Applications/Xcode.app').and_return(false)
+    end
+
+    recipe do
+      xcode '9.4.1'
+    end
+
+    it { is_expected.not_to run_execute('install Command Line Tools') }
+    it { is_expected.not_to render_file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') }
+
+    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.not_to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+
+  context 'with requested Xcode installed at a different path, and with CLT present' do
+    before(:each) do
+      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
+        .and_return(["9.4.1\t(/Applications/Some_Weird_Path.app)\t\n"])
+      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
+                                     .and_return(true)
+      stub_command('test -L /Applications/Xcode.app').and_return(false)
+    end
+
+    recipe do
+      xcode '9.4.1' do
+        path '/Applications/Chef_Managed_Xcode.app'
+      end
+    end
+
+    it { is_expected.not_to run_execute('install Command Line Tools') }
+    it { is_expected.not_to render_file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') }
+
+    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Some_Weird_Path.app to /Applications/Chef_Managed_Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Chef_Managed_Xcode.app') }
+  end
+
+  context 'with requested Xcode version not installed, and something at the requested path' do
+    before(:each) do
+      allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
+        .and_return(["9.3\t(/Applications/Xcode.app)\t\n"])
+      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
+                                     .and_return(false)
+      stub_command('test -L /Applications/Xcode.app').and_return(true)
+    end
+
+    recipe do
+      xcode '9.4.1' do
+        path '/Applications/Xcode.app'
+      end
+    end
+
+    it {
+      expect(chef_run.execute('install Command Line Tools'))
+        .to notify('file[sentinel to request on-demand install]')
+        .to(:create).before
+    }
+    it { is_expected.to run_execute('install Command Line Tools') }
+
+    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -73,8 +73,8 @@ describe 'xcode' do
     before(:each) do
       allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
         .and_return([])
-      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
-                                     .and_return(false)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(false)
       stub_command('test -L /Applications/Xcode.app').and_return(true)
     end
 
@@ -100,8 +100,8 @@ describe 'xcode' do
     before(:each) do
       allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
         .and_return([])
-      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
-                                     .and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(true)
     end
 
@@ -123,8 +123,8 @@ describe 'xcode' do
     before(:each) do
       allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
         .and_return(["9.4.1\t(/Applications/Xcode.app)\t\n"])
-      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
-                                     .and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
     end
 
@@ -146,8 +146,8 @@ describe 'xcode' do
     before(:each) do
       allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
         .and_return(["9.4.1\t(/Applications/Some_Weird_Path.app)\t\n"])
-      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
-                                     .and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
     end
 
@@ -171,8 +171,8 @@ describe 'xcode' do
     before(:each) do
       allow_any_instance_of(MacOS::Xcode).to receive(:installed_xcodes)
         .and_return(["9.3\t(/Applications/Xcode.app)\t\n"])
-      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
-                                     .and_return(false)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(false)
       stub_command('test -L /Applications/Xcode.app').and_return(true)
     end
 

--- a/test/cookbooks/macos_test/recipes/xcode.rb
+++ b/test/cookbooks/macos_test/recipes/xcode.rb
@@ -1,8 +1,4 @@
 if node['platform_version'].match? Regexp.union '10.13'
-  execute 'Disable Gatekeeper' do
-    command ['spctl', '--master-disable']
-  end
-
   include_recipe 'macos::xcode'
 
 elsif node['platform_version'].match? Regexp.union '10.12'

--- a/test/integration/default/controls/xcode_test.rb
+++ b/test/integration/default/controls/xcode_test.rb
@@ -8,7 +8,6 @@ control 'xcode-and-simulators' do
   '
 
   macos_version = command('/usr/bin/sw_vers -productVersion').stdout.strip
-
   describe directory('/Applications/Xcode.app') do
     it { should exist }
     it { should_not be_symlink }
@@ -24,6 +23,21 @@ control 'xcode-and-simulators' do
     describe command('/opt/chef/embedded/bin/xcversion simulators') do
       its('exit_status') { should eq 0 }
       its('stdout') { should include 'iOS 9.3 Simulator (installed)' }
+    end
+  end
+end
+
+control 'xcode-beta' do
+  title 'beta integrated development environment for macOS'
+  desc '
+    Verify that Xcode exists in a beta-supported platform
+  '
+
+  macos_version = command('/usr/bin/sw_vers -productVersion').stdout.strip
+  if macos_version.match? Regexp.union '10.13'
+    describe directory('/Applications/Xcode.app') do
+      it { should exist }
+      it { should_not be_symlink }
     end
   end
 end

--- a/test/integration/default/controls/xcode_test.rb
+++ b/test/integration/default/controls/xcode_test.rb
@@ -3,56 +3,27 @@ title 'xcode'
 control 'xcode-and-simulators' do
   title 'integrated development environment for macOS'
   desc '
-    Verify that Xcode exists, developer mode is enabled, and the expected
-    simulators are installed using the xcversion commandline utility
+    Verify that Xcode exists, and the expected simulators are installed using
+    the xcversion commandline utility
   '
 
   macos_version = command('/usr/bin/sw_vers -productVersion').stdout.strip
 
-  describe file('/Applications/Xcode.app') do
+  describe directory('/Applications/Xcode.app') do
     it { should exist }
-    it { should be_symlink }
+    it { should_not be_symlink }
   end
 
-  if macos_version.match? Regexp.union '10.13'
-    describe directory('/Applications/Xcode-9.4.1.app') do
-      it { should exist }
-    end
-
-  elsif macos_version.match? Regexp.union '10.12'
-    describe directory('/Applications/Xcode-9.2.app') do
-      it { should exist }
-    end
-
+  if macos_version.match? Regexp.union '10.12'
     describe command('/opt/chef/embedded/bin/xcversion simulators') do
       its('exit_status') { should eq 0 }
       its('stdout') { should include 'iOS 10.3.1 Simulator (installed)' }
     end
 
   elsif macos_version.match? Regexp.union '10.11'
-    describe directory('/Applications/Xcode-8.2.1.app') do
-      it { should exist }
-    end
-
     describe command('/opt/chef/embedded/bin/xcversion simulators') do
       its('exit_status') { should eq 0 }
       its('stdout') { should include 'iOS 9.3 Simulator (installed)' }
-    end
-  end
-end
-
-control 'xcode-beta' do
-  title 'beta integrated development environment for macOS'
-  desc '
-    Verify that Xcode beta exists, developer mode is enabled, and the expected
-    simulators are installed using the xcversion commandline utility
-  '
-
-  macos_version = command('/usr/bin/sw_vers -productVersion').stdout.strip
-
-  if macos_version.match? Regexp.union '10.13'
-    describe directory('/Applications/Xcode-10.app') do
-      it { should exist }
     end
   end
 end


### PR DESCRIPTION
This PR implements a `path` property for Xcode, which will move the requested Xcode bundle to the specified path, and set the active developer directory to that location as well.

If the requested version of Xcode is already present, it will move that version of Xcode to the requested path, overwriting if necessary.  

The logic for this is tested at the resource, rather than library level, which requires `chefspec >= 7.3.0`. Because of this, this PR also fixes a new ShellOutNotStubbed failure with the `disable_software_update` spec.

Resolves #116 