### PR TITLE
Release/2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.0] - 2018-09-10
+### Added
+- Added functional `path` property to Xcode resource. ([Issue #116](https://github.com/Microsoft/macos-cookbook/issues/116)).
+- Added ChefSpec resource tests for Xcode.
+
+### Fixed
+- Separated extra responsibilities of Xcode resource into DeveloperAccount and
+CommandLineTools libraries.
+
 ## [2.4.0] - 2018-08-16
 ### Added
 - Added `CHANGELOG.md`. ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).

--- a/documentation/resource_xcode.md
+++ b/documentation/resource_xcode.md
@@ -3,11 +3,14 @@ xcode
 
 Use the **xcode** resource to manage a single installation of Apple's Xcode IDE.
 An **xcode** resource instance represents the state of a single Xcode installation
-and any simulators that are declared using the `ios_simulators` property. The latest
-version of iOS simulators are always installed with Xcode. This resource supports
-beta and GM seeds from Apple if currently available via your developer credentials.
-Be sure to only provide the semantic version (e.g. `9.4` and not `9.4 beta` or
-`10 GM seed`) in the version property.
+and any additional iOS simulators that are declared using the `ios_simulators`
+property. The latest version of iOS simulators are always installed with Xcode.
+This resource supports beta and GM seeds from Apple if currently available via
+your developer credentials. Be sure to only provide the semantic version (e.g.
+`10.0` and not `10 beta` or `10 GM seed`) in the version property. Providing a
+`path` will move an existing Xcode installation of the requested version to that
+path, overwriting an existing bundle if it is not the requested version.
+
 
 Syntax
 ------
@@ -15,10 +18,10 @@ Syntax
 The simplest use of an **xcode** resource is:
 
 ```ruby
-xcode '9.3'
+xcode '9.4.1'
 ```
 
-which would install Xcode 9.3 with the default simulators.
+which would install Xcode 9.4.1 with the included iOS simulators.
 
 The full syntax for all of the properties that are available to the **xcode**
 resource is:
@@ -27,24 +30,34 @@ resource is:
 xcode 'description' do
   version                              String # defaults to 'description' if not specified
   path                                 String # defaults to '/Applications/Xcode.app' if not specified
-  ios_simulators                       Array # defaults to [10, 11] if not specified
-  action                               Symbol # defaults to [:install_xcode, :install_simulators] if not specified
+  ios_simulators                       Array # defaults to current iOS simulators if not specified
+  action                               Symbol # defaults to [:install_gem, :install_xcode, :install_simulators] if not specified
 end
 ```
 
 Actions
 -------
+It is recommended to use the default action of all three actions, since the
+`xcode-install` gem is required to use the resource. Only use actions independently
+if you're going to manage this dependency on your own.
 
 This resource has the following actions:
 
+`:install_gem`
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Install the `xcode-install` gem dependency,
+downloading the required Apple Command Line tools if not already present.
+
 `:install_xcode`
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Set `entry` to `value` in `path`
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Download and install the specified `version`
+of Xcode from Apple, move the specified `path`, and make it the active developer
+directory for the node.
 
 `:install_simulators`
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Along with a `version` of Xcode,
-install the declared array of the major versions of `ios_simulators`.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Download and install latest major version
+of iOS simulators declared in `ios_simulators`.
 
 Examples
 --------

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -2,22 +2,30 @@ include Chef::Mixin::ShellOut
 
 module MacOS
   class CommandLineTools
-    attr_reader :product
+    attr_reader :version
 
     def initialize
-      @product = if available_command_line_tools.empty?
-                   'none'
+      install_sentinel = '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+      FileUtils.touch install_sentinel
+      FileUtils.chown 'root', 'wheel', install_sentinel
+
+      @version = if available_command_line_tools.empty?
+                   'Unavailable from Software Update Catalog'
                  else
                    available_command_line_tools.last.tr('*', '').strip
                  end
     end
 
     def available_command_line_tools
-      available_products.lines.select { |s| s.include?('* Command') }
+      softwareupdate_list.select { |product_name| product_name.include?('* Command Line Tools') }
     end
 
-    def available_products
-      shell_out(['softwareupdate', '--list']).stdout
+    def softwareupdate_list
+      shell_out(['softwareupdate', '--list']).stdout.lines
+    end
+
+    def installed?
+      ::File.exist?('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
     end
   end
 end

--- a/libraries/developer_account.rb
+++ b/libraries/developer_account.rb
@@ -1,0 +1,33 @@
+include Chef::Mixin::ShellOut
+include MacOS
+
+module MacOS
+  class DeveloperAccount
+    attr_reader :credentials
+
+    def initialize(data_bag_retrieval = nil, node_credential_attributes = nil)
+      developer_id = find_apple_id(data_bag_retrieval, node_credential_attributes)
+      @credentials = { XCODE_INSTALL_USER:     developer_id['apple_id'],
+                       XCODE_INSTALL_PASSWORD: developer_id['password'] }
+      authenticate_with_apple(@credentials)
+    end
+
+    def authenticate_with_apple(credentials)
+      shell_out!(XCVersion.update, env: credentials)
+    end
+
+    def find_apple_id(data_bag_retrieval, node_credential_attributes)
+      if node_credential_attributes
+        { 'apple_id' => node_credential_attributes['user'],
+          'password' => node_credential_attributes['password'] }
+      else
+        data_bag_retrieval.call
+      end
+    rescue Net::HTTPServerException
+      Chef::Application.fatal!('No developer credentials supplied!')
+    end
+  end
+end
+
+Chef::Recipe.include(MacOS)
+Chef::Resource.include(MacOS)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -28,7 +28,12 @@ module MacOS
       end
 
       def installed_xcodes
-        xcversion + 'installed'
+        lines = shell_out(xcversion + 'installed').stdout.lines
+        lines.map { |line| { line.split.first => line.split.last.delete('()') } }
+      end
+
+      def available_versions
+        shell_out!(XCVersion.list_xcodes).stdout.lines
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.4.0'
+version '2.5.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require_relative '../libraries/plist'
 require_relative '../libraries/system'
 require_relative '../libraries/xcode'
 require_relative '../libraries/xcversion'
+require_relative '../libraries/developer_account'
 require_relative '../libraries/command_line_tools'
 require_relative '../libraries/security_cmd'
 

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -4,21 +4,21 @@ include MacOS
 describe MacOS::CommandLineTools do
   context 'when provided an available list of software update products' do
     before do
-      allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_products)
-        .and_return(<<~SOFTWAREUPDATE_LIST
-                    Software Update Tool
-                    Finding available software
-                    Software Update found the following new or updated software:
-                       * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2
-                    \tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]
-                       * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2
-                    \tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.2), 177376K [recommended]
-                    SOFTWAREUPDATE_LIST
+      allow(FileUtils).to receive(:touch).and_return(true)
+      allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                     "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.2), 177376K [recommended]\n"]
                    )
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
-      expect(clt.product).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2'
+      expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2'
     end
   end
 end

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -4,11 +4,7 @@ include MacOS
 describe MacOS::Xcode do
   context 'when initialized with developer credentials and Xcode betas available' do
     before do
-      allow_any_instance_of(MacOS::Xcode).to receive(:authenticate_with_apple)
-        .and_return(true)
-      allow_any_instance_of(MacOS::Xcode).to receive(:find_apple_id)
-        .and_return('apple_id': 'apple_id', 'password': 'password')
-      allow_any_instance_of(MacOS::Xcode).to receive(:available_versions_list)
+      allow(MacOS::XCVersion).to receive(:available_versions)
         .and_return(["4.3 for Lion\n",
                      "4.3.1 for Lion\n",
                      "4.3.2 for Lion\n",
@@ -56,28 +52,30 @@ describe MacOS::Xcode do
                      "9.1\n",
                      "9.2\n",
                      "9.3\n",
-                     "9.4 beta\n",
+                     "9.4\n",
+                     "9.4.1\n",
+                     "9.4.2 beta\n",
                      "10 GM seed\n"]
                    )
     end
     it 'returns the name of Xcode 10 GM when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('10.0')
+      xcode = MacOS::Xcode.new('10.0', '/Applications/Xcode.app')
       expect(xcode.version).to eq '10 GM seed'
     end
     it 'returns the name of Xcode 9.4 beta when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('9.4')
-      expect(xcode.version).to eq '9.4 beta'
+      xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
+      expect(xcode.version).to eq '9.4.2 beta'
     end
     it 'returns the name of Xcode 9.3 when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('9.3')
+      xcode = MacOS::Xcode.new('9.3', '/Applications/Xcode.app')
       expect(xcode.version).to eq '9.3'
     end
     it 'returns the name of Xcode 9 when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('9.0')
+      xcode = MacOS::Xcode.new('9.0', '/Applications/Xcode.app')
       expect(xcode.version).to eq '9'
     end
     it 'returns the name of Xcode 8.3.3 when initialized with the semantic version' do
-      xcode = MacOS::Xcode.new('8.3.3')
+      xcode = MacOS::Xcode.new('8.3.3', '/Applications/Xcode.app')
       expect(xcode.version).to eq '8.3.3'
     end
   end

--- a/spec/unit/recipes/disable_software_updates_spec.rb
+++ b/spec/unit/recipes/disable_software_updates_spec.rb
@@ -5,6 +5,8 @@ describe 'macos::disable_software_updates' do
     let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
     it 'converges successfully' do
+      allow_any_instance_of(MacOS::SoftwareUpdates).to receive(:automatic_check_disabled?)
+        .and_return(false)
       expect { chef_run }.to_not raise_error
     end
   end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -1,0 +1,188 @@
+require 'spec_helper'
+
+describe 'xcode' do
+  step_into :xcode
+  platform 'mac_os_x'
+
+  default_attributes['macos']['apple_id']['user'] = 'developer@apple.com'
+  default_attributes['macos']['apple_id']['password'] = 'apple_id_password'
+
+  before(:each) do
+    allow_any_instance_of(MacOS::DeveloperAccount).to receive(:authenticate_with_apple)
+      .and_return(true)
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_command_line_tools)
+      .and_return(["   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n"])
+    allow(MacOS::XCVersion).to receive(:available_versions)
+      .and_return(["4.3 for Lion\n",
+                   "4.3.1 for Lion\n",
+                   "4.3.2 for Lion\n",
+                   "4.3.3 for Lion\n",
+                   "4.4\n",
+                   "4.4.1\n",
+                   "4.5\n",
+                   "4.5.1\n",
+                   "4.5.2\n",
+                   "4.6\n",
+                   "4.6.1\n",
+                   "4.6.2\n",
+                   "4.6.3\n",
+                   "5\n",
+                   "5.0.1\n",
+                   "5.0.2\n",
+                   "5.1\n",
+                   "5.1.1\n",
+                   "6.0.1\n",
+                   "6.1\n",
+                   "6.1.1\n",
+                   "6.2\n",
+                   "6.3\n",
+                   "6.3.1\n",
+                   "6.3.2\n",
+                   "6.4\n",
+                   "7\n",
+                   "7.0.1\n",
+                   "7.1\n",
+                   "7.1.1\n",
+                   "7.2\n",
+                   "7.2.1\n",
+                   "7.3\n",
+                   "7.3.1\n",
+                   "8\n",
+                   "8.1\n",
+                   "8.2\n",
+                   "8.2.1\n",
+                   "8.3\n",
+                   "8.3.1\n",
+                   "8.3.2\n",
+                   "8.3.3\n",
+                   "9\n",
+                   "9.0.1\n",
+                   "9.1\n",
+                   "9.2\n",
+                   "9.3\n",
+                   "9.4\n",
+                   "9.4.1\n",
+                   "9.4.2 beta\n",
+                   "10 GM seed\n"]
+                 )
+    allow(File).to receive(:exist?).and_call_original
+    allow(FileUtils).to receive(:touch).and_return(true)
+    allow(FileUtils).to receive(:chown).and_return(true)
+  end
+
+  context 'with no Xcodes installed, and no CLT installed' do
+    before(:each) do
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(false)
+      stub_command('test -L /Applications/Xcode.app').and_return(true)
+    end
+
+    recipe do
+      xcode '9.4.1'
+    end
+
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+
+    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+
+  context 'with no Xcodes installed, and with CLT installed' do
+    before(:each) do
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(true)
+      stub_command('test -L /Applications/Xcode.app').and_return(true)
+    end
+
+    recipe do
+      xcode '9.4.1'
+    end
+
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+
+    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+
+  context 'with requested Xcode installed, and with CLT installed' do
+    before(:each) do
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([{ '9.4.1' => '/Applications/Xcode.app' }])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(true)
+      stub_command('test -L /Applications/Xcode.app').and_return(false)
+    end
+
+    recipe do
+      xcode '9.4.1'
+    end
+
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+
+    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.not_to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+
+  context 'with requested Xcode installed at a different path, and with CLT present' do
+    before(:each) do
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([{ '9.4.1' => '/Applications/Some_Weird_Path.app' }])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(true)
+      stub_command('test -L /Applications/Xcode.app').and_return(false)
+    end
+
+    recipe do
+      xcode '9.4.1' do
+        path '/Applications/Chef_Managed_Xcode.app'
+      end
+    end
+
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+
+    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Some_Weird_Path.app to /Applications/Chef_Managed_Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Chef_Managed_Xcode.app') }
+  end
+
+  context 'with requested Xcode version not installed, and something at the requested path' do
+    before(:each) do
+      allow(MacOS::XCVersion).to receive(:installed_xcodes)
+        .and_return([{ '9.3' => '/Applications/Xcode.app' }])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
+        .and_return(false)
+      stub_command('test -L /Applications/Xcode.app').and_return(true)
+    end
+
+    recipe do
+      xcode '9.4.1' do
+        path '/Applications/Xcode.app'
+      end
+    end
+
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+
+    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to delete_link('/Applications/Xcode.app') }
+
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
+  end
+end

--- a/test/cookbooks/macos_test/recipes/xcode.rb
+++ b/test/cookbooks/macos_test/recipes/xcode.rb
@@ -1,8 +1,4 @@
 if node['platform_version'].match? Regexp.union '10.13'
-  execute 'Disable Gatekeeper' do
-    command ['spctl', '--master-disable']
-  end
-
   include_recipe 'macos::xcode'
 
 elsif node['platform_version'].match? Regexp.union '10.12'

--- a/test/integration/default/controls/xcode_test.rb
+++ b/test/integration/default/controls/xcode_test.rb
@@ -3,37 +3,23 @@ title 'xcode'
 control 'xcode-and-simulators' do
   title 'integrated development environment for macOS'
   desc '
-    Verify that Xcode exists, developer mode is enabled, and the expected
-    simulators are installed using the xcversion commandline utility
+    Verify that Xcode exists, and the expected simulators are installed using
+    the xcversion commandline utility
   '
 
   macos_version = command('/usr/bin/sw_vers -productVersion').stdout.strip
-
-  describe file('/Applications/Xcode.app') do
+  describe directory('/Applications/Xcode.app') do
     it { should exist }
-    it { should be_symlink }
+    it { should_not be_symlink }
   end
 
-  if macos_version.match? Regexp.union '10.13'
-    describe directory('/Applications/Xcode-9.4.1.app') do
-      it { should exist }
-    end
-
-  elsif macos_version.match? Regexp.union '10.12'
-    describe directory('/Applications/Xcode-9.2.app') do
-      it { should exist }
-    end
-
+  if macos_version.match? Regexp.union '10.12'
     describe command('/opt/chef/embedded/bin/xcversion simulators') do
       its('exit_status') { should eq 0 }
       its('stdout') { should include 'iOS 10.3.1 Simulator (installed)' }
     end
 
   elsif macos_version.match? Regexp.union '10.11'
-    describe directory('/Applications/Xcode-8.2.1.app') do
-      it { should exist }
-    end
-
     describe command('/opt/chef/embedded/bin/xcversion simulators') do
       its('exit_status') { should eq 0 }
       its('stdout') { should include 'iOS 9.3 Simulator (installed)' }
@@ -44,15 +30,14 @@ end
 control 'xcode-beta' do
   title 'beta integrated development environment for macOS'
   desc '
-    Verify that Xcode beta exists, developer mode is enabled, and the expected
-    simulators are installed using the xcversion commandline utility
+    Verify that Xcode exists in a beta-supported platform
   '
 
   macos_version = command('/usr/bin/sw_vers -productVersion').stdout.strip
-
   if macos_version.match? Regexp.union '10.13'
-    describe directory('/Applications/Xcode-10.app') do
+    describe directory('/Applications/Xcode.app') do
       it { should exist }
+      it { should_not be_symlink }
     end
   end
 end


### PR DESCRIPTION
## [2.5.0] - 2018-09-10
### Added
- Added functional `path` property to Xcode resource. ([Issue #116](https://github.com/Microsoft/macos-cookbook/issues/116)).
- Added ChefSpec resource tests for Xcode.

### Fixed
- Separated extra responsibilities of Xcode resource into `DeveloperAccount` and
`CommandLineTools` libraries.