### PR TITLE
Use more meaningful values instead of magic numbers

### DIFF
--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -18,10 +18,15 @@ all_privileges = text_messages | control_observe | send_files |
 
 control 'remote-control' do
   title 'naprivs value represents remote control for all users'
-  desc 'Verify that naprivs has the magic value to indicate all privileges'
+  desc 'Verify that naprivs has the magic value to indicate all privileges and that it is activated.'
 
   describe command('/usr/libexec/PlistBuddy -c Print /Library/Preferences/com.apple.RemoteManagement.plist') do
     its('stdout') { should match 'ARD_AllLocalUsers = true' }
     its('stdout') { should match /#{all_privileges}/ }
+  end
+
+  describe file('/Library/Application Support/Apple/Remote Desktop/RemoteManagement.launchd') do
+    it { should exist }
+    its('content') { should match 'enabled' }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -17,8 +17,10 @@ all_privileges = text_messages | control_observe | send_files |
                  change_settings | restart_shutdown | show_observe
 
 control 'remote-control' do
-  title 'naprivs value represents remote control for all users'
-  desc 'Verify that naprivs has the magic value to indicate all privileges and that it is activated.'
+  title 'ensure that remote access and control will function'
+  desc "ensure that the Remote Management plist grants local users access, that
+        all privileges are granted based on the mask #{all_privileges}, and that
+        remote control is enabled"
 
   describe command('/usr/libexec/PlistBuddy -c Print /Library/Preferences/com.apple.RemoteManagement.plist') do
     its('stdout') { should match 'ARD_AllLocalUsers = true' }

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -1,14 +1,27 @@
 title 'remote access'
 
+user_has_access  = 1 << 31
+text_messages    = 1 << 0
+control_observe  = 1 << 1
+send_files       = 1 << 2
+delete_files     = 1 << 3
+generate_reports = 1 << 4
+open_quit_apps   = 1 << 5
+change_settings  = 1 << 6
+restart_shutdown = 1 << 7
+show_observe     = 1 << 30
+
+priv = text_messages | control_observe | send_files | delete_files | generate_reports | open_quit_apps | change_settings | restart_shutdown | show_observe
+
 control 'remote-control' do
   title 'naprivs value represents remote control for all users'
-  desc 'verify that naprivs has the bitmask value -1073741569'
+  desc "verify that naprivs has the bitmask value #{priv}"
 
-  describe command('/usr/bin/dscl . list /Users naprivs') do
-    its('stdout') { should match 'vagrant   -2147483648' }
+  describe command("/usr/bin/dscl . list /Users naprivs | tr -ds 'vagrant-' '[:space:]'") do
+    its('stdout.to_i') { should match user_has_access }
   end
 
   describe command('defaults read /Library/Preferences/com.apple.RemoteManagement ARD_AllLocalUsersPrivs') do
-    its('stdout') { should match '1073742079' }
+    its('stdout.to_i') { should match priv }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -1,6 +1,6 @@
 title 'remote access'
 
-user_has_access  = 1 << 31
+# user_has_access  = 1 << 31
 text_messages    = 1 << 0
 control_observe  = 1 << 1
 send_files       = 1 << 2
@@ -9,6 +9,7 @@ generate_reports = 1 << 4
 open_quit_apps   = 1 << 5
 change_settings  = 1 << 6
 restart_shutdown = 1 << 7
+# observe_only     = 1 << 8
 show_observe     = 1 << 30
 
 all_privileges = text_messages | control_observe | send_files |
@@ -17,17 +18,10 @@ all_privileges = text_messages | control_observe | send_files |
 
 control 'remote-control' do
   title 'naprivs value represents remote control for all users'
-  desc "verify that naprivs has the bitmask value #{all_privileges}"
-
-  describe command('/usr/bin/dscl . list /Users naprivs') do
-    its('stdout') { should match /#{user_has_access}/ }
-  end
-
-  describe command('defaults read /Library/Preferences/com.apple.RemoteManagement ARD_AllLocalUsersPrivs') do
-    its('stdout') { should cmp all_privileges }
-  end
+  desc 'Verify that naprivs has the magic value to indicate all privileges'
 
   describe command('/usr/libexec/PlistBuddy -c Print /Library/Preferences/com.apple.RemoteManagement.plist') do
     its('stdout') { should match 'ARD_AllLocalUsers = true' }
+    its('stdout') { should match /#{all_privileges}/ }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -11,18 +11,20 @@ change_settings  = 1 << 6
 restart_shutdown = 1 << 7
 show_observe     = 1 << 30
 
-priv = text_messages | control_observe | send_files | delete_files | generate_reports | open_quit_apps | change_settings | restart_shutdown | show_observe
+all_privileges = text_messages | control_observe | send_files |
+                 delete_files | generate_reports | open_quit_apps |
+                 change_settings | restart_shutdown | show_observe
 
 control 'remote-control' do
   title 'naprivs value represents remote control for all users'
-  desc "verify that naprivs has the bitmask value #{priv}"
+  desc "verify that naprivs has the bitmask value #{all_privileges}"
 
-  describe command("/usr/bin/dscl . list /Users naprivs | tr -ds 'vagrant-' '[:space:]'") do
-    its('stdout.to_i') { should match user_has_access }
+  describe command('/usr/bin/dscl . list /Users naprivs') do
+    its('stdout') { should match /#{user_has_access}/ }
   end
 
   describe command('defaults read /Library/Preferences/com.apple.RemoteManagement ARD_AllLocalUsersPrivs') do
-    its('stdout.to_i') { should match priv }
+    its('stdout') { should cmp all_privileges }
   end
 
   describe command('/usr/libexec/PlistBuddy -c Print /Library/Preferences/com.apple.RemoteManagement.plist') do


### PR DESCRIPTION
2147483648 and 1073742079 can both be represented by bits as per the kickstart perl script. 
With this PR, what each number represents is more clearly known. 

- Define bit values as per the kickstart perl script in `/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart`
- Use the bit values for the integration test.
