### PR TITLE
Prevent additional Command Line Tools from appearing in softwareupdate

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -115,6 +115,7 @@ suites:
   verifier:
     controls:
     - xcode-and-simulators
+    - command-line-tool-sentinel
 
 - name: xcode-beta
   run_list:
@@ -122,6 +123,7 @@ suites:
   verifier:
     controls:
     - xcode-beta
+    - command-line-tool-sentinel
 
 - name: certificate
   run_list:

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -20,6 +20,10 @@ module MacOS
       softwareupdate_list.select { |product_name| product_name.include?('* Command Line Tools') }
     end
 
+    def macos_version
+      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/10\.\d+/]
+    end
+
     def softwareupdate_list
       shell_out(['softwareupdate', '--list']).stdout.lines
     end

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -9,14 +9,14 @@ module MacOS
       FileUtils.touch install_sentinel
       FileUtils.chown 'root', 'wheel', install_sentinel
 
-      @version = if available_command_line_tools.empty?
+      @version = if available.empty?
                    'Unavailable from Software Update Catalog'
                  else
                    available_command_line_tools.last.tr('*', '').strip
                  end
     end
 
-    def available_command_line_tools
+    def available
       softwareupdate_list.select { |product_name| product_name.include?('* Command Line Tools') }
     end
 

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -12,8 +12,12 @@ module MacOS
       @version = if available.empty?
                    'Unavailable from Software Update Catalog'
                  else
-                   available_command_line_tools.last.tr('*', '').strip
+                   platform_specific.last.tr('*', '').strip
                  end
+    end
+
+    def platform_specific
+      available.select { |product_name| product_name.include? macos_version }
     end
 
     def available

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -12,8 +12,13 @@ module MacOS
       @version = if available.empty?
                    'Unavailable from Software Update Catalog'
                  else
-                   platform_specific.last.tr('*', '').strip
+                   latest.tr('*', '').strip
                  end
+    end
+
+    def latest
+      versions = platform_specific.map { |product| Gem::Version.new xcode_version(product) }
+      platform_specific.detect { |product| product.include? versions.max.version }
     end
 
     def platform_specific
@@ -22,6 +27,10 @@ module MacOS
 
     def available
       softwareupdate_list.select { |product_name| product_name.include?('* Command Line Tools') }
+    end
+
+    def xcode_version(product)
+      product.match(/Xcode-(?<version>\d+\.\d+)/)['version']
     end
 
     def macos_version

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -14,6 +14,10 @@ action :install_gem do
     live_stream true
   end
 
+  file '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress' do
+    action :delete
+  end
+
   chef_gem 'xcode-install' do
     options('--no-document --no-user-install')
   end

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -8,12 +8,18 @@ describe MacOS::CommandLineTools do
       allow(FileUtils).to receive(:chown).and_return(true)
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
         .and_return(["Software Update Tool\n",
-                     "Finding available software\n",
+                     "\n", "Finding available software\n",
                      "Software Update found the following new or updated software:\n",
                      "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
                      "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
-                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2\n",
-                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.2), 177376K [recommended]\n"]
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (10.0), 190520K [recommended]\n",
+                     "   * Command Line Tools (macOS Mojave version 10.14) for Xcode-10.0\n",
+                     "\tCommand Line Tools (macOS Mojave version 10.14) for Xcode (10.0), 187321K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
                    )
     end
     it 'returns the latest recommended Command Line Tools product' do

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -6,6 +6,8 @@ describe MacOS::CommandLineTools do
     before do
       allow(FileUtils).to receive(:touch).and_return(true)
       allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+        .and_return('10.14')
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
         .and_return(["Software Update Tool\n",
                      "\n", "Finding available software\n",

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -24,7 +24,7 @@ describe MacOS::CommandLineTools do
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
-      expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2'
+      expect(clt.version).to eq 'Command Line Tools (macOS Mojave version 10.14) for Xcode-10.0'
     end
   end
 end

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 include MacOS
 
 describe MacOS::CommandLineTools do
-  context 'when provided an available list of software update products' do
+  context 'when provided an available list of software update products in Mojave' do
     before do
       allow(FileUtils).to receive(:touch).and_return(true)
       allow(FileUtils).to receive(:chown).and_return(true)
@@ -27,6 +27,32 @@ describe MacOS::CommandLineTools do
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
       expect(clt.version).to eq 'Command Line Tools (macOS Mojave version 10.14) for Xcode-10.0'
+    end
+  end
+
+  context 'when provided an available list of software update products in High Sierra' do
+    before do
+      allow(FileUtils).to receive(:touch).and_return(true)
+      allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+        .and_return('10.13')
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "\n", "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                     "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (10.0), 190520K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
+                   )
+    end
+    it 'returns the latest recommended Command Line Tools product' do
+      clt = MacOS::CommandLineTools.new
+      expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0'
     end
   end
 end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -95,15 +95,15 @@ describe 'xcode' do
     end
 
     recipe do
-      xcode '9.4.1'
+      xcode '10.0'
     end
 
-    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to run_execute('install Xcode 10.0') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
@@ -117,58 +117,58 @@ describe 'xcode' do
     end
 
     recipe do
-      xcode '9.4.1'
+      xcode '10.0'
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to run_execute('install Xcode 10.0') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
   context 'with requested Xcode installed, and with CLT installed' do
     before(:each) do
       allow(MacOS::XCVersion).to receive(:installed_xcodes)
-        .and_return([{ '9.4.1' => '/Applications/Xcode.app' }])
+        .and_return([{ '10.0' => '/Applications/Xcode.app' }])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
     end
 
     recipe do
-      xcode '9.4.1'
+      xcode '10.0'
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to run_execute('install Xcode 10.0') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.not_to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.not_to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
   context 'with requested Xcode installed at a different path, and with CLT present' do
     before(:each) do
       allow(MacOS::XCVersion).to receive(:installed_xcodes)
-        .and_return([{ '9.4.1' => '/Applications/Some_Weird_Path.app' }])
+        .and_return([{ '10.0' => '/Applications/Some_Weird_Path.app' }])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
     end
 
     recipe do
-      xcode '9.4.1' do
+      xcode '10.0' do
         path '/Applications/Chef_Managed_Xcode.app'
       end
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to run_execute('install Xcode 10.0') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
 
     it { is_expected.to run_execute('move /Applications/Some_Weird_Path.app to /Applications/Chef_Managed_Xcode.app') }
@@ -185,17 +185,17 @@ describe 'xcode' do
     end
 
     recipe do
-      xcode '9.4.1' do
+      xcode '10.0' do
         path '/Applications/Xcode.app'
       end
     end
 
-    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to run_execute('install Xcode 10.0') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -10,10 +10,23 @@ describe 'xcode' do
   before(:each) do
     allow_any_instance_of(MacOS::DeveloperAccount).to receive(:authenticate_with_apple)
       .and_return(true)
-    allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_command_line_tools)
-      .and_return(["   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+      .and_return('10.13')
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+      .and_return(["Software Update Tool\n",
+                   "\n", "Finding available software\n",
+                   "Software Update found the following new or updated software:\n",
+                   "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                   "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0\n",
+                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (10.0), 190520K [recommended]\n",
+                   "   * Command Line Tools (macOS Mojave version 10.14) for Xcode-10.0\n",
+                   "\tCommand Line Tools (macOS Mojave version 10.14) for Xcode (10.0), 187321K [recommended]\n",
                    "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
-                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n"])
+                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
+                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
+                 )
     allow(MacOS::XCVersion).to receive(:available_versions)
       .and_return(["4.3 for Lion\n",
                    "4.3.1 for Lion\n",

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -28,7 +28,9 @@ describe 'xcode' do
                    "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
                  )
     allow(MacOS::XCVersion).to receive(:available_versions)
-      .and_return(["4.3 for Lion\n",
+      .and_return(["10\n",
+                   "10.1 beta 2\n",
+                   "4.3 for Lion\n",
                    "4.3.1 for Lion\n",
                    "4.3.2 for Lion\n",
                    "4.3.3 for Lion\n",
@@ -75,10 +77,9 @@ describe 'xcode' do
                    "9.1\n",
                    "9.2\n",
                    "9.3\n",
+                   "9.3.1\n",
                    "9.4\n",
-                   "9.4.1\n",
-                   "9.4.2 beta\n",
-                   "10 GM seed\n"]
+                   "9.4.1\n"]
                  )
     allow(File).to receive(:exist?).and_call_original
     allow(FileUtils).to receive(:touch).and_return(true)
@@ -100,7 +101,7 @@ describe 'xcode' do
 
     it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 10.0') }
+    it { is_expected.to run_execute('install Xcode 10') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
     it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
@@ -122,7 +123,7 @@ describe 'xcode' do
 
     it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 10.0') }
+    it { is_expected.to run_execute('install Xcode 10') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
     it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
@@ -144,7 +145,7 @@ describe 'xcode' do
 
     it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.not_to run_execute('install Xcode 10.0') }
+    it { is_expected.not_to run_execute('install Xcode 10') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
 
     it { is_expected.not_to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
@@ -168,7 +169,7 @@ describe 'xcode' do
 
     it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.not_to run_execute('install Xcode 10.0') }
+    it { is_expected.not_to run_execute('install Xcode 10') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
 
     it { is_expected.to run_execute('move /Applications/Some_Weird_Path.app to /Applications/Chef_Managed_Xcode.app') }
@@ -192,7 +193,7 @@ describe 'xcode' do
 
     it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 10.0') }
+    it { is_expected.to run_execute('install Xcode 10') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
     it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }

--- a/test/integration/default/controls/xcode_test.rb
+++ b/test/integration/default/controls/xcode_test.rb
@@ -41,3 +41,18 @@ control 'xcode-beta' do
     end
   end
 end
+
+control 'command-line-tool-sentinel' do
+  title 'Command Line Tools sentinel has been deleted'
+  desc '
+    Verify that the Command Line Tools sentinel has been deleted, and that
+    there are no lingering CLT updates since we should have installed the latest
+  '
+  describe file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') do
+    it { should_not exist }
+  end
+
+  describe command('/usr/sbin/softwareupdate --list') do
+    its('stdout') { should_not include 'Command Line Tools' }
+  end
+end


### PR DESCRIPTION
This PR cleans up the CLT sentinel file after the `xcode` `:install_gem` action to prevent the behavior as described in #142 (thanks, @mattlqx)

The `command_line_tools_spec` has been updated with some new Mojave output, and an integration test has been added to specific test for #142. 