### PR TITLE
Release/2.6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -115,6 +115,7 @@ suites:
   verifier:
     controls:
     - xcode-and-simulators
+    - command-line-tool-sentinel
 
 - name: xcode-beta
   run_list:
@@ -122,6 +123,7 @@ suites:
   verifier:
     controls:
     - xcode-beta
+    - command-line-tool-sentinel
 
 - name: certificate
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -140,3 +140,10 @@ suites:
     - keychain-creation
     - login-keychain-creation
     - default-keychain-creation
+
+- name: remote-access
+  run_list:
+  - recipe[macos_test::remote_access]
+  verifier:
+    controls:
+    - remote-control

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,19 +16,6 @@ verifier:
   - test/integration/default
 
 platforms:
-- name: el-capitan-chef13
-  driver:
-    box: microsoft/os-x-el-capitan
-    version: 10.11.6
-  provisioner:
-    product_version: 13
-
-- name: el-capitan-chef14
-  driver:
-    box: microsoft/os-x-el-capitan
-    version: 10.11.6
-  provisioner:
-    product_version: 14
 
 - name: sierra-chef13
   driver:
@@ -55,6 +42,20 @@ platforms:
   driver:
     box: microsoft/macos-high-sierra
     version: 10.13.5
+  provisioner:
+    product_version: 14
+
+- name: mojave-chef13
+  driver:
+    box: microsoft/macos-mojave
+    version: 10.14.0
+  provisioner:
+    product_version: 13
+
+- name: mojave-chef14
+  driver:
+    box: microsoft/macos-mojave
+    version: 10.14.0
   provisioner:
     product_version: 14
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,20 @@ verifier:
 
 platforms:
 
+- name: el-capitan-chef13
+  driver:
+    box: microsoft/os-x-el-capitan
+    version: 10.11.6
+  provisioner:
+    product_version: 13
+
+- name: el-capitan-chef14
+  driver:
+    box: microsoft/os-x-el-capitan
+    version: 10.11.6
+  provisioner:
+    product_version: 14
+
 - name: sierra-chef13
   driver:
     box: microsoft/macos-sierra

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,14 +48,14 @@ platforms:
 - name: high-sierra-chef13
   driver:
     box: microsoft/macos-high-sierra
-    version: 10.13.5
+    version: 10.13.6-v2
   provisioner:
     product_version: 13
 
 - name: high-sierra-chef14
   driver:
     box: microsoft/macos-high-sierra
-    version: 10.13.5
+    version: 10.13.6-v2
   provisioner:
     product_version: 14
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -117,14 +117,6 @@ suites:
     - xcode-and-simulators
     - command-line-tool-sentinel
 
-- name: xcode-beta
-  run_list:
-  - recipe[macos_test::xcode_beta]
-  verifier:
-    controls:
-    - xcode-beta
-    - command-line-tool-sentinel
-
 - name: certificate
   run_list:
   - recipe[macos_test::certificate]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,14 +62,14 @@ platforms:
 - name: mojave-chef13
   driver:
     box: microsoft/macos-mojave
-    version: 10.14.0
+    version: 10.14.01
   provisioner:
     product_version: 13
 
 - name: mojave-chef14
   driver:
     box: microsoft/macos-mojave
-    version: 10.14.0
+    version: 10.14.01
   provisioner:
     product_version: 14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [2.6.0] - 2018-09-27
+## [2.6.0] - 2018-10-03
 ### Added
-- Apple increased the security for the kickstart command in macOS Mojave, which we use to configure the remote management settings. Despite Apple's warning of Remote Management not being activated, we have a test that verifies it still activates.
+- Apple has limited some kickstart command functionality in macOS Mojave, preventing screen
+control in some invocations. We verified the `ard` resource's implementations of kickstart still
+function, and added tests to validate the default actions of `ard`.
+
+- Updated Xcode default version to 10.0.
+
 - The team crossed the great Mojave Desert, collapsed from dehydration, all just to obtain its support. In other words we now support macOS Mojave.
-- Updated Xcode to support version 10.
+
+### Fixed
+- Prevented the `xcode` resource from leaving available Command Line Tools downloads
+in Software Updates.
 
 ### Deprecated
 - The `machine_name` resource has been deprecated in favor of the macOS support in the `hostname` resource in Chef 14. It will be removed in the release of v3.0 of the macOS cookbook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.0] - 2018-09-27
+### Added
+- Apple increased the security for the kickstart command in macOS Mojave, which we use to configure the remote management settings. Despite Apple's warning of Remote Management not being activated, we have a test that verifies it still activates.
+- The team crossed the great Mojave Desert, collapsed from dehydration, all just to obtain its support. In other words we now support macOS Mojave.
+- Updated Xcode to support version 10.
+
 ## [2.5.0] - 2018-09-10
 ### Added
 - Added functional `path` property to Xcode resource. ([Issue #116](https://github.com/Microsoft/macos-cookbook/issues/116)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - The team crossed the great Mojave Desert, collapsed from dehydration, all just to obtain its support. In other words we now support macOS Mojave.
 - Updated Xcode to support version 10.
 
+### Deprecated
+- The `machine_name` resource has been deprecated in favor of the macOS support in the `hostname` resource in Chef 14. It will be removed in the release of v3.0 of the macOS cookbook.
+
 ## [2.5.0] - 2018-09-10
 ### Added
 - Added `CHANGELOG.md`, About time right? ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [2.6.0] - 2018-10-03
 ### Added
 - Apple has limited some kickstart command functionality in macOS Mojave, preventing screen
-control in some invocations. We verified the `ard` resource's implementations of kickstart still
-function, and added tests to validate the default actions of `ard`.
+control in some invocations. We verified the `ard` resource's implementation of the `kickstart` script still functions.
 
 - Updated Xcode default version to 10.0.
 
@@ -41,7 +40,7 @@ CommandLineTools libraries.
 
 ## [2.3.0] - 2018-06-28
 ### Added
-- Like a trained ninja of the night, the `macos_user` now has a hidden property, making it impossible to detect from the login screen.
+- Like a trained ninja of the night, the `macos_user` now has a `hidden` property, making it impossible to detect from the login screen.
 - Moved to a new set of internal Vagrant macOS boxes, which have much more minimal initial configuration. This ensures that our resources run from a more out-of-the-box macOS experience.
 
 ### Fixed
@@ -50,7 +49,7 @@ CommandLineTools libraries.
 
 ## [2.2.0] - 2018-05-29
 ### Added
-- FoodCritics can be pretty harsh in their critiquing of food. They also have some pretty in depth rules we need to comply with, so we updated machine_name to comply with the new FoodCritic rule FC115.
+- Foodcritics can be pretty harsh in their critiquing of food. They also have some pretty in depth rules we need to comply with, so we updated machine_name to comply with the new FoodCritic rule FC115.
 - Added guard config to automatically run relevant unit tests when a file is changed.
 - Update to InSpec control filenames to match the standard. This allows for better understanding of the tests.
 
@@ -99,7 +98,7 @@ CommandLineTools libraries.
 ## [1.9.0] - 2018-03-21
 ### Added
 - Added support for other hypervisors and keep away logic.
-- Implemented `-t` option in certificate resource to allow apps to access imported key.
+- Implemented `-t` option in `certificate` resource to allow apps to access imported key.
 - Add `utf-8` encoding type to `plist` resource to make it more robust.
 
 ## [1.8.0] - 2018-03-12

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default['macos']['admin_user'] = 'vagrant'
 default['macos']['admin_password'] = 'vagrant'
 
-default['macos']['xcode']['version'] = '9.4.1'
+default['macos']['xcode']['version'] = '10.0'
 
 default['macos']['remote_login_enabled'] = true
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.5.0'
+version '2.6.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/recipes/xcode.rb
+++ b/recipes/xcode.rb
@@ -1,4 +1,4 @@
-if node['platform_version'].match? Regexp.union '10.13'
+if node['platform_version'].match? Regexp.union '10.14|10.13'
   execute 'Disable Gatekeeper' do
     command ['spctl', '--master-disable']
   end

--- a/recipes/xcode.rb
+++ b/recipes/xcode.rb
@@ -1,4 +1,4 @@
-if node['platform_version'].match? Regexp.union '10.14|10.13'
+if node['platform_version'].match? Regexp.union /10.14|10.13/
   execute 'Disable Gatekeeper' do
     command ['spctl', '--master-disable']
   end

--- a/resources/ard.rb
+++ b/resources/ard.rb
@@ -17,7 +17,6 @@ property :clientopts, Array
 action :activate do
   execute BASE_COMMAND do
     command "#{BASE_COMMAND} -activate"
-    live_stream true
   end
 end
 
@@ -73,6 +72,5 @@ action :configure do
   end
   execute BASE_COMMAND do
     command "#{BASE_COMMAND} -configure #{configure_options.join(' ')}"
-    live_stream true
   end
 end

--- a/resources/ard.rb
+++ b/resources/ard.rb
@@ -1,4 +1,5 @@
 resource_name :ard
+default_action %i(activate configure)
 
 BASE_COMMAND = '/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart'.freeze
 

--- a/resources/ard.rb
+++ b/resources/ard.rb
@@ -17,6 +17,7 @@ property :clientopts, Array
 action :activate do
   execute BASE_COMMAND do
     command "#{BASE_COMMAND} -activate"
+    live_stream true
   end
 end
 
@@ -72,5 +73,6 @@ action :configure do
   end
   execute BASE_COMMAND do
     command "#{BASE_COMMAND} -configure #{configure_options.join(' ')}"
+    live_stream true
   end
 end

--- a/resources/machine_name.rb
+++ b/resources/machine_name.rb
@@ -1,5 +1,7 @@
 resource_name :machine_name
 
+deprecated 'The `machine_name` resource is deprecated, and will be removed in the release of v3.0 of the macOS cookbook.'
+
 property :hostname, String, desired_state: true, coerce: proc { |name| conform_to_dns_standards(name) }, name_property: true
 property :computer_name, String, desired_state: true
 property :local_hostname, String, desired_state: true, coerce: proc { |name| conform_to_dns_standards(name) }

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -34,8 +34,8 @@ end
 action :set do
   volume = MetadataUtil.new(target_volume)
 
-  service 'spotlight server' do
-    service_name 'mds'
+  macosx_service 'metadata server' do
+    service_name 'com.apple.metadata.mds'
     plist '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist'
     action [:enable, :start]
   end

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -14,6 +14,10 @@ action :install_gem do
     live_stream true
   end
 
+  file '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress' do
+    action :delete
+  end
+
   chef_gem 'xcode-install' do
     options('--no-document --no-user-install')
   end

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -2,23 +2,57 @@ require 'spec_helper'
 include MacOS
 
 describe MacOS::CommandLineTools do
-  context 'when provided an available list of software update products' do
+  context 'when provided an available list of software update products in Mojave' do
     before do
       allow(FileUtils).to receive(:touch).and_return(true)
       allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+        .and_return('10.14')
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
         .and_return(["Software Update Tool\n",
-                     "Finding available software\n",
+                     "\n", "Finding available software\n",
                      "Software Update found the following new or updated software:\n",
                      "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
                      "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
-                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2\n",
-                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.2), 177376K [recommended]\n"]
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (10.0), 190520K [recommended]\n",
+                     "   * Command Line Tools (macOS Mojave version 10.14) for Xcode-10.0\n",
+                     "\tCommand Line Tools (macOS Mojave version 10.14) for Xcode (10.0), 187321K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
                    )
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
-      expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.2'
+      expect(clt.version).to eq 'Command Line Tools (macOS Mojave version 10.14) for Xcode-10.0'
+    end
+  end
+
+  context 'when provided an available list of software update products in High Sierra' do
+    before do
+      allow(FileUtils).to receive(:touch).and_return(true)
+      allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+        .and_return('10.13')
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "\n", "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                     "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (10.0), 190520K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
+                   )
+    end
+    it 'returns the latest recommended Command Line Tools product' do
+      clt = MacOS::CommandLineTools.new
+      expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0'
     end
   end
 end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -10,12 +10,27 @@ describe 'xcode' do
   before(:each) do
     allow_any_instance_of(MacOS::DeveloperAccount).to receive(:authenticate_with_apple)
       .and_return(true)
-    allow_any_instance_of(MacOS::CommandLineTools).to receive(:available_command_line_tools)
-      .and_return(["   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+      .and_return('10.13')
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+      .and_return(["Software Update Tool\n",
+                   "\n", "Finding available software\n",
+                   "Software Update found the following new or updated software:\n",
+                   "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                   "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0\n",
+                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (10.0), 190520K [recommended]\n",
+                   "   * Command Line Tools (macOS Mojave version 10.14) for Xcode-10.0\n",
+                   "\tCommand Line Tools (macOS Mojave version 10.14) for Xcode (10.0), 187321K [recommended]\n",
                    "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
-                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n"])
+                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
+                   "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
+                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
+                 )
     allow(MacOS::XCVersion).to receive(:available_versions)
-      .and_return(["4.3 for Lion\n",
+      .and_return(["10\n",
+                   "10.1 beta 2\n",
+                   "4.3 for Lion\n",
                    "4.3.1 for Lion\n",
                    "4.3.2 for Lion\n",
                    "4.3.3 for Lion\n",
@@ -62,10 +77,9 @@ describe 'xcode' do
                    "9.1\n",
                    "9.2\n",
                    "9.3\n",
+                   "9.3.1\n",
                    "9.4\n",
-                   "9.4.1\n",
-                   "9.4.2 beta\n",
-                   "10 GM seed\n"]
+                   "9.4.1\n"]
                  )
     allow(File).to receive(:exist?).and_call_original
     allow(FileUtils).to receive(:touch).and_return(true)
@@ -82,15 +96,15 @@ describe 'xcode' do
     end
 
     recipe do
-      xcode '9.4.1'
+      xcode '10.0'
     end
 
-    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to run_execute('install Xcode 10') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
@@ -104,58 +118,58 @@ describe 'xcode' do
     end
 
     recipe do
-      xcode '9.4.1'
+      xcode '10.0'
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to run_execute('install Xcode 10') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
   context 'with requested Xcode installed, and with CLT installed' do
     before(:each) do
       allow(MacOS::XCVersion).to receive(:installed_xcodes)
-        .and_return([{ '9.4.1' => '/Applications/Xcode.app' }])
+        .and_return([{ '10.0' => '/Applications/Xcode.app' }])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
     end
 
     recipe do
-      xcode '9.4.1'
+      xcode '10.0'
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to run_execute('install Xcode 10') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.not_to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.not_to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
   context 'with requested Xcode installed at a different path, and with CLT present' do
     before(:each) do
       allow(MacOS::XCVersion).to receive(:installed_xcodes)
-        .and_return([{ '9.4.1' => '/Applications/Some_Weird_Path.app' }])
+        .and_return([{ '10.0' => '/Applications/Some_Weird_Path.app' }])
       allow_any_instance_of(MacOS::CommandLineTools).to receive(:installed?)
         .and_return(true)
       stub_command('test -L /Applications/Xcode.app').and_return(false)
     end
 
     recipe do
-      xcode '9.4.1' do
+      xcode '10.0' do
         path '/Applications/Chef_Managed_Xcode.app'
       end
     end
 
-    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.not_to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.not_to run_execute('install Xcode 9.4.1') }
+    it { is_expected.not_to run_execute('install Xcode 10') }
     it { is_expected.not_to delete_link('/Applications/Xcode.app') }
 
     it { is_expected.to run_execute('move /Applications/Some_Weird_Path.app to /Applications/Chef_Managed_Xcode.app') }
@@ -172,17 +186,17 @@ describe 'xcode' do
     end
 
     recipe do
-      xcode '9.4.1' do
+      xcode '10.0' do
         path '/Applications/Xcode.app'
       end
     end
 
-    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4') }
+    it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
 
-    it { is_expected.to run_execute('install Xcode 9.4.1') }
+    it { is_expected.to run_execute('install Xcode 10') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.1.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 end

--- a/test/cookbooks/macos_test/recipes/remote_access.rb
+++ b/test/cookbooks/macos_test/recipes/remote_access.rb
@@ -1,0 +1,1 @@
+ard 'activate and configure remote management for all users'

--- a/test/cookbooks/macos_test/recipes/xcode.rb
+++ b/test/cookbooks/macos_test/recipes/xcode.rb
@@ -1,4 +1,4 @@
-if node['platform_version'].match? Regexp.union '10.13'
+if node['platform_version'].match? Regexp.union '10.14|10.13'
   include_recipe 'macos::xcode'
 
 elsif node['platform_version'].match? Regexp.union '10.12'

--- a/test/cookbooks/macos_test/recipes/xcode.rb
+++ b/test/cookbooks/macos_test/recipes/xcode.rb
@@ -1,13 +1,1 @@
-if node['platform_version'].match? Regexp.union '10.14|10.13'
-  include_recipe 'macos::xcode'
-
-elsif node['platform_version'].match? Regexp.union '10.12'
-  xcode '9.2' do
-    ios_simulators %w(11 10)
-  end
-
-elsif node['platform_version'].match? Regexp.union '10.11'
-  xcode '8.2.1' do
-    ios_simulators %w(10 9)
-  end
-end
+include_recipe 'macos::xcode'

--- a/test/cookbooks/macos_test/recipes/xcode_beta.rb
+++ b/test/cookbooks/macos_test/recipes/xcode_beta.rb
@@ -1,5 +1,0 @@
-execute 'Disable Gatekeeper' do
-  command ['spctl', '--master-disable']
-end
-
-xcode '10.0' if node['platform_version'].match? Regexp.union '10.13'

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -4,11 +4,7 @@ control 'remote-control' do
   title 'naprivs value represents remote control for all users'
   desc 'verify that naprivs has the bitmask value -1073741569'
 
-  describe command '/usr/bin/dscl . list /Users naprivs' do
-    its('stdout') { should_match /vagrant -1073741569/ }
-  end
-
-  describe command "sudo -E PlistBuddy -c 'Print naprivs:0' /var/db/dslocal/nodes/Default/users/vagrant.plist" do
-    its('stdout') { should_match /-1073741569/ }
+  describe command('/usr/bin/dscl . list /Users naprivs') do
+    its('stdout') { should match 'vagrant   -1073741569' }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -1,16 +1,14 @@
-title 'ard'
+title 'remote access'
 
-dscl = '/usr/bin/dscl'
+control 'remote-control' do
+  title 'naprivs value represents remote control for all users'
+  desc 'verify that naprivs has the bitmask value -1073741569'
 
-control 'naprivs' do
-  title 'naprivs value for remote management'
-  desc 'Verify that naprivs in the users.plist has the value -1073741569'
-
-  describe command ('#{dscl} . list /Users naprivs') do
-      its('stdout') { should_match (/vagrant -1073741569/) }
+  describe command '/usr/bin/dscl . list /Users naprivs' do
+    its('stdout') { should_match /vagrant -1073741569/ }
   end
 
-  describe command ("sudo -E PlistBuddy -c 'Print naprivs:0' /var/db/dslocal/nodes/Default/users/vagrant.plist") do
-    its('stdout') { should_match (/-1073741569/) }
+  describe command "sudo -E PlistBuddy -c 'Print naprivs:0' /var/db/dslocal/nodes/Default/users/vagrant.plist" do
+    its('stdout') { should_match /-1073741569/ }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -2,13 +2,22 @@ title 'remote access'
 
 control 'remote-control' do
   title 'naprivs value represents remote control for all users'
-  desc 'verify that naprivs has the bitmask value -1073741569'
+  desc 'Verify that naprivs has the magic value to indicate all privileges'
 
-  describe command('/usr/bin/dscl . list /Users naprivs') do
-    its('stdout') { should match 'vagrant   -2147483648' }
-  end
+  # user_has_access  = 0b1 << 31
+  # text_messages    = 0b1 << 0
+  # control_observe  = 0b1 << 1
+  # send_files       = 0b1 << 2
+  # delete_files     = 0b1 << 3
+  # generate_reports = 0b1 << 4
+  # open_quit_apps   = 0b1 << 5
+  # change_settings  = 0b1 << 6
+  # restart_shutDown = 0b1 << 7
+  # observe_only     = 0b1 << 8
+  # show_observe     = 0b1 << 30
 
-  describe command('defaults read /Library/Preferences/com.apple.RemoteManagement ARD_AllLocalUsersPrivs') do
-    its('stdout') { should match '1073742079' }
+  describe command('/usr/libexec/PlistBuddy -c Print /Library/Preferences/com.apple.RemoteManagement.plist') do
+    its('stdout') { should match 'ARD_AllLocalUsers = true' }
+    its('stdout') { should match 'ARD_AllLocalUsersPrivs = 1073742079' }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -1,23 +1,34 @@
 title 'remote access'
 
-control 'remote-control' do
-  title 'naprivs value represents remote control for all users'
-  desc 'Verify that naprivs has the magic value to indicate all privileges'
+# user_has_access  = 1 << 31
+text_messages    = 1 << 0
+control_observe  = 1 << 1
+send_files       = 1 << 2
+delete_files     = 1 << 3
+generate_reports = 1 << 4
+open_quit_apps   = 1 << 5
+change_settings  = 1 << 6
+restart_shutdown = 1 << 7
+# observe_only     = 1 << 8
+show_observe     = 1 << 30
 
-  # user_has_access  = 0b1 << 31
-  # text_messages    = 0b1 << 0
-  # control_observe  = 0b1 << 1
-  # send_files       = 0b1 << 2
-  # delete_files     = 0b1 << 3
-  # generate_reports = 0b1 << 4
-  # open_quit_apps   = 0b1 << 5
-  # change_settings  = 0b1 << 6
-  # restart_shutDown = 0b1 << 7
-  # observe_only     = 0b1 << 8
-  # show_observe     = 0b1 << 30
+all_privileges = text_messages | control_observe | send_files |
+                 delete_files | generate_reports | open_quit_apps |
+                 change_settings | restart_shutdown | show_observe
+
+control 'remote-control' do
+  title 'ensure that remote access and control will function'
+  desc "ensure that the Remote Management plist grants local users access, that
+        all privileges are granted based on the mask #{all_privileges}, and that
+        remote control is enabled"
 
   describe command('/usr/libexec/PlistBuddy -c Print /Library/Preferences/com.apple.RemoteManagement.plist') do
     its('stdout') { should match 'ARD_AllLocalUsers = true' }
-    its('stdout') { should match 'ARD_AllLocalUsersPrivs = 1073742079' }
+    its('stdout') { should match /#{all_privileges}/ }
+  end
+
+  describe file('/Library/Application Support/Apple/Remote Desktop/RemoteManagement.launchd') do
+    it { should exist }
+    its('content') { should match 'enabled' }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -5,6 +5,10 @@ control 'remote-control' do
   desc 'verify that naprivs has the bitmask value -1073741569'
 
   describe command('/usr/bin/dscl . list /Users naprivs') do
-    its('stdout') { should match 'vagrant   -1073741569' }
+    its('stdout') { should match 'vagrant   -2147483648' }
+  end
+
+  describe command('defaults read /Library/Preferences/com.apple.RemoteManagement ARD_AllLocalUsersPrivs') do
+    its('stdout') { should match '1073742079' }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -1,16 +1,16 @@
-title `ard`
+title 'ard'
 
-dscl = /usr/bin/dscl
+dscl = '/usr/bin/dscl'
 
-control `naprivs` do
-  title `naprivs value for remote management`
-  desc `Verify that naprivs in the users.plist has the value -1073741569`
+control 'naprivs' do
+  title 'naprivs value for remote management'
+  desc 'Verify that naprivs in the users.plist has the value -1073741569'
 
-  describe command (`#{dscl} . list /Users naprivs`) do
+  describe command ('#{dscl} . list /Users naprivs') do
       its('stdout') { should_match (/vagrant -1073741569/) }
   end
 
-  describe command (`sudo -E PlistBuddy -c 'Print naprivs:0' /var/db/dslocal/nodes/Default/users/vagrant.plist`) do
+  describe command ("sudo -E PlistBuddy -c 'Print naprivs:0' /var/db/dslocal/nodes/Default/users/vagrant.plist") do
     its('stdout') { should_match (/-1073741569/) }
   end
 end

--- a/test/integration/default/controls/ard_test.rb
+++ b/test/integration/default/controls/ard_test.rb
@@ -1,0 +1,16 @@
+title `ard`
+
+dscl = /usr/bin/dscl
+
+control `naprivs` do
+  title `naprivs value for remote management`
+  desc `Verify that naprivs in the users.plist has the value -1073741569`
+
+  describe command (`#{dscl} . list /Users naprivs`) do
+      its('stdout') { should_match (/vagrant -1073741569/) }
+  end
+
+  describe command (`sudo -E PlistBuddy -c 'Print naprivs:0' /var/db/dslocal/nodes/Default/users/vagrant.plist`) do
+    its('stdout') { should_match (/-1073741569/) }
+  end
+end

--- a/test/integration/default/controls/xcode_test.rb
+++ b/test/integration/default/controls/xcode_test.rb
@@ -41,3 +41,18 @@ control 'xcode-beta' do
     end
   end
 end
+
+control 'command-line-tool-sentinel' do
+  title 'Command Line Tools sentinel has been deleted'
+  desc '
+    Verify that the Command Line Tools sentinel has been deleted, and that
+    there are no lingering CLT updates since we should have installed the latest
+  '
+  describe file('/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress') do
+    it { should_not exist }
+  end
+
+  describe command('/usr/sbin/softwareupdate --list') do
+    its('stdout') { should_not include 'Command Line Tools' }
+  end
+end


### PR DESCRIPTION
The team crossed the great Mojave Desert, collapsed from dehydration, all just to obtain support. In other words we now support macOS Mojave.

## [2.6.0] - 2018-10-03
### Added
- Apple has limited some kickstart command functionality in macOS Mojave, preventing screen
control in some invocations. We verified the `ard` resource's implementations of kickstart still
function, and added tests to validate the default actions of `ard`.

- Updated Xcode default version to 10.0.

### Fixed
- Prevented the `xcode` resource from leaving available Command Line Tools downloads
in Software Updates.