### PR TITLE
 Issue#129 Resolving broken links in README

### DIFF
--- a/documentation/resource_certificate.md
+++ b/documentation/resource_certificate.md
@@ -7,7 +7,7 @@ command in the `security_cmd` library.
 
 [Learn more about certificates](https://developer.apple.com/library/content/documentation/Security/Conceptual/cryptoservices/KeyManagementAPIs/KeyManagementAPIs.html).
 
-[Learn more about `security`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/security.1.html).
+[Learn more about `security`](http://mirror.informatimago.com/next/developer.apple.com/documentation/Darwin/Reference/ManPages/man1/security.1.html).
 
 Syntax
 ------

--- a/documentation/resource_keychain.md
+++ b/documentation/resource_keychain.md
@@ -7,7 +7,7 @@ command in the `security_cmd` library.
 
 [Learn more about keychains](https://support.apple.com/kb/PH20093?locale=en_US).
 
-[Learn more about `security`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/security.1.html).
+[Learn more about `security`](http://mirror.informatimago.com/next/developer.apple.com/documentation/Darwin/Reference/ManPages/man1/security.1.html).
 
 Syntax
 ------

--- a/documentation/resource_plist.md
+++ b/documentation/resource_plist.md
@@ -13,9 +13,9 @@ before changing any values. It also makes sure that the plist is in binary forma
 so that the settings can be interpreted correctly by the operating system.
 
 Prior knowledge of using commandline utilities such as
-[defaults](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/defaults.1.html),
-[plutil](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/plutil.1.html),
-and [PlistBuddy](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/PlistBuddy.8.html)
+[defaults](http://mirror.informatimago.com/next/developer.apple.com/documentation/Darwin/Reference/ManPages/man1/defaults.1.html),
+[plutil](http://mirror.informatimago.com/next/developer.apple.com/documentation/Darwin/Reference/ManPages/man1/plutil.1.html),
+and [PlistBuddy](http://www.manpagez.com/man/8/PlistBuddy/)
 will be useful when implementing the **plist** resource.
 
 Want to learn more? See the [Property List Programming Guide](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/PropertyLists/QuickStartPlist/QuickStartPlist.html#//apple_ref/doc/uid/10000048i-CH4-SW5).

--- a/documentation/resource_spotlight.md
+++ b/documentation/resource_spotlight.md
@@ -8,7 +8,7 @@ command in the `metadata_util` library.
 
 [Learn more about Spotlight](https://support.apple.com/en-us/HT204014).
 
-[Learn more about `mdutil`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/mdutil.1.html).
+[Learn more about `mdutil`](http://mirror.informatimago.com/next/developer.apple.com/documentation/Darwin/Reference/ManPages/man1/mdutil.1.html).
 
 Syntax
 ------


### PR DESCRIPTION
Addressing to: https://github.com/Microsoft/macos-cookbook/issues/129

Well, seems like apple really removed online man pages.
This was a workaround to keep the info on the README, otherwise I guess we should just remove the links. For the `PlistBuddy` link tho, I linked that to a totally different man page, please look into that.