### PR TITLE
Release/2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.1] - 2018-10-04
+### Added
+- The desert took its toll, the README now declares support for Mojave!
+
 ## [2.6.0] - 2018-10-03
 ### Added
 - Apple has limited some kickstart command functionality in macOS Mojave, preventing screen

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Supported OS Versions
 - OS X El Capitan 10.11
 - macOS Sierra 10.12
 - macOS High Sierra 10.13
+- macOS Mojave 10.14
 
 Attributes
 ----------
@@ -66,8 +67,7 @@ to always keep macOS on and available.
 
 ### Xcode
 
-Installs Xcode 9.2 and simulators for iOS 10 and iOS 11. See the
-[Xcode resource documentation](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_xcode.md) if you need
+Installs the latest Xcode the platform supports. See the [Xcode resource documentation](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_xcode.md) if you need
 more flexibility.
 
 :warning: Requires a `credentials` data bag containing an `apple_id` data bag item,

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.6.0'
+version '2.6.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'


### PR DESCRIPTION
## [2.6.1] - 2018-10-04
### Added
- The desert took its toll, the README now declares support for Mojave!