### PR TITLE
Add multi-converge testing for all suites, idempotency for select suites

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,7 @@ driver:
 
 provisioner:
   product_name: chef
-  multiple_converge: 2
+  multiple_converge: 3
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -114,8 +114,6 @@ suites:
     - indexing-and-searching
 
 - name: xcode
-  provisioner:
-    enforce_idempotency: true
   run_list:
   - recipe[macos_test::xcode]
   verifier:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,8 @@ driver:
 
 provisioner:
   product_name: chef
+  multiple_converge: 2
+  enforce_idempotency: true
 
 verifier:
   name: inspec
@@ -85,9 +87,6 @@ suites:
     - updates-disabled
 
 - name: power-management
-  provisioner:
-    multiple_converge: 2
-    enforce_idempotency: true
   run_list:
   - recipe[macos::keep_awake]
   verifier:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,6 @@ verifier:
   - test/integration/default
 
 platforms:
-
 - name: el-capitan-chef13
   driver:
     box: microsoft/os-x-el-capitan
@@ -111,6 +110,9 @@ suites:
   verifier:
     controls:
     - indexing-and-searching
+  lifecycle:
+    pre_verify:
+    - sleep 20
 
 - name: xcode
   provisioner:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -105,14 +105,13 @@ suites:
     - nonstandard-computer-name
 
 - name: spotlight
+  provisioner:
+    enforce_idempotency: true
   run_list:
   - recipe[macos_test::spotlight]
   verifier:
     controls:
     - indexing-and-searching
-  lifecycle:
-    pre_verify:
-    - sleep 60
 
 - name: xcode
   provisioner:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,7 @@ driver:
 
 provisioner:
   product_name: chef
-  multiple_converge: 3
+  multiple_converge: 2
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,6 @@ driver:
 provisioner:
   product_name: chef
   multiple_converge: 2
-  enforce_idempotency: true
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -112,7 +112,7 @@ suites:
     - indexing-and-searching
   lifecycle:
     pre_verify:
-    - sleep 20
+    - sleep 60
 
 - name: xcode
   provisioner:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -76,6 +76,8 @@ platforms:
 
 suites:
 - name: default
+  provisioner:
+    enforce_idempotency: true
   run_list:
   - recipe[macos::disable_software_updates]
   - recipe[macos_test::preferences]
@@ -86,6 +88,8 @@ suites:
     - updates-disabled
 
 - name: power-management
+  provisioner:
+    enforce_idempotency: true
   run_list:
   - recipe[macos::keep_awake]
   verifier:
@@ -109,6 +113,8 @@ suites:
     - indexing-and-searching
 
 - name: xcode
+  provisioner:
+    enforce_idempotency: true
   run_list:
   - recipe[macos_test::xcode]
   verifier:

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -8,7 +8,8 @@ module MacOS
     def initialize(volume)
       mdutil_possible_states = { 'Indexing enabled.' => ['on', ''],
                                  'Indexing disabled.' => ['off', ''],
-                                 'Indexing and searching disabled.' => ['off', '-d'] }
+                                 'Indexing and searching disabled.' => ['off', '-d'],
+                                 'Error' => ['', ''] }
 
       @mdutil_output = shell_out('/usr/bin/mdutil', '-s', volume).stdout
       @status_flags = unless server_disabled?

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -12,13 +12,7 @@ module MacOS
                                  'Error' => ['', ''] }
 
       @mdutil_output = shell_out('/usr/bin/mdutil', '-s', volume).stdout
-      @status_flags = unless server_disabled?
-                        mdutil_possible_states[volume_current_state(volume)].insert(1, volume)
-                      end
-    end
-
-    def server_disabled?
-      mdutil_output.strip.include? 'disabled'
+      @status_flags = mdutil_possible_states[volume_current_state(volume)].insert(1, volume)
     end
 
     def volume_current_state(_volume)

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -32,8 +32,6 @@ action_class do
 end
 
 action :set do
-  volume = MetadataUtil.new(target_volume)
-
   macosx_service 'metadata server' do
     service_name 'com.apple.metadata.mds'
     plist '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist'
@@ -42,6 +40,6 @@ action :set do
 
   execute "turn Spotlight indexing #{state} for #{target_volume}" do
     command mdutil + desired_spotlight_state.insert(0, '-i')
-    not_if { volume.status_flags == desired_spotlight_state }
+    not_if { MetadataUtil.new(target_volume).status_flags == desired_spotlight_state }
   end
 end

--- a/resources/system_preference.rb
+++ b/resources/system_preference.rb
@@ -20,11 +20,6 @@ action :set do
     converge_by "set #{new_resource.preference} to #{new_resource.setting}" do
       set_pref = ['-set', new_resource.preference.to_s].join('')
       execute ['/usr/sbin/systemsetup', set_pref, new_resource.setting]
-      ruby_block 'sleep one second' do
-        block do
-          sleep 1
-        end
-      end
     end
   end
 end

--- a/resources/system_preference.rb
+++ b/resources/system_preference.rb
@@ -20,6 +20,8 @@ action :set do
     converge_by "set #{new_resource.preference} to #{new_resource.setting}" do
       set_pref = ['-set', new_resource.preference.to_s].join('')
       execute ['/usr/sbin/systemsetup', set_pref, new_resource.setting]
+      execute ['/usr/sbin/systemsetup', set_pref, new_resource.setting]
+      execute ['/usr/sbin/systemsetup', set_pref, new_resource.setting]
     end
   end
 end

--- a/test/cookbooks/macos_test/recipes/spotlight.rb
+++ b/test/cookbooks/macos_test/recipes/spotlight.rb
@@ -14,6 +14,7 @@ end
 
 execute 'test' do
   command ['sudo', 'launchctl', 'unload', '-w', '/System/Library/LaunchDaemons/com.apple.metadata.mds.plist']
+  not_if 'diskutil info TDD-ROM'
 end
 
 spotlight '/'

--- a/test/cookbooks/macos_test/recipes/spotlight.rb
+++ b/test/cookbooks/macos_test/recipes/spotlight.rb
@@ -8,7 +8,7 @@ test_volumes.each do |volume|
              '-size', '1g', '-format', 'UDRW',
              '-volname', volume, '-srcfolder', test_file,
              '-ov', '-attach']
-    not_if 'diskutil info test_disk1'
+    not_if 'diskutil info TDD-ROM'
   end
 end
 

--- a/test/cookbooks/macos_test/recipes/spotlight.rb
+++ b/test/cookbooks/macos_test/recipes/spotlight.rb
@@ -8,6 +8,7 @@ test_volumes.each do |volume|
              '-size', '1g', '-format', 'UDRW',
              '-volname', volume, '-srcfolder', test_file,
              '-ov', '-attach']
+    not_if 'diskutil info test_disk1'
   end
 end
 

--- a/test/integration/default/controls/users_and_groups_test.rb
+++ b/test/integration/default/controls/users_and_groups_test.rb
@@ -6,7 +6,6 @@ control 'admin-user' do
 
   describe user('randall') do
     it { should exist }
-    its('uid') { should eq 503 }
     its('gid') { should eq 20 }
     its('home') { should eq '/Users/randall' }
     its('groups') { should include 'alpha' }
@@ -49,7 +48,6 @@ control 'standard-user' do
 
   describe user('johnny') do
     it { should exist }
-    its('uid') { should eq 504 }
     its('gid') { should eq 20 }
     its('home') { should eq '/Users/johnny' }
     its('groups') { should include 'staff' }
@@ -75,7 +73,6 @@ control 'standard-user' do
 
   describe user('paul') do
     it { should exist }
-    its('uid') { should eq 505 }
     its('groups') { should include 'staff' }
     its('groups') { should_not include  'admin' }
     its('home') { should eq '/Users/paul' }


### PR DESCRIPTION
This PR adds multi-converge testing for all suites, and idempotency enforcement for `spotlight` and `keep_awake` testing. 

It also fixes bugs related to enabling these options in `spotlight` and `keep_awake`.