### PR TITLE
Feature/fix doc links

### DIFF
--- a/documentation/resource_ard.md
+++ b/documentation/resource_ard.md
@@ -1,8 +1,8 @@
 ard
 ===
 
-Use the [**ard**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/ard.rb) resource to manage the "Remote Management" settings, found in System
-Preferences > Sharing > Remote Management. Under the hood, the **ard** resource
+Use the **ard** resource to manage the "Remote Management" settings, found in System
+Preferences > Sharing > Remote Management. Under the hood, the [**ard**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/ard.rb) resource
 executes the `kickstart` command, located in ARDAgent.app (one of macOS' "core services").
 
 Syntax
@@ -28,7 +28,7 @@ The default `:configure` action is equivalent to the following
 ![Sharing Preferences](sharing_preferences.png)
 
 The full syntax for all of the properties that are available to the **ard**
-resource are:
+resource is:
 
 ```ruby
 ard 'description' do

--- a/documentation/resource_ard.md
+++ b/documentation/resource_ard.md
@@ -28,7 +28,7 @@ The default `:configure` action is equivalent to the following
 ![Sharing Preferences](sharing_preferences.png)
 
 The full syntax for all of the properties that are available to the **ard**
-resource is:
+resource are:
 
 ```ruby
 ard 'description' do

--- a/documentation/resource_ard.md
+++ b/documentation/resource_ard.md
@@ -4,9 +4,6 @@ ard
 Use the **ard** resource to manage the "Remote Management" settings, found in System
 Preferences > Sharing > Remote Management. Under the hood, an **ard** resource
 executes the `kickstart` command, located in ARDAgent.app (one of macOS' "core services").
-It has some basic actions, which pertain to the simple `kickstart` subcommands.
-It also has the more complicated `:configure` action, which requires some familiarity
-with [`kickstart`](https://support.apple.com/en-us/HT201710).
 
 Syntax
 ------
@@ -23,7 +20,7 @@ end
 where
 
 - `:activate` activates the ARD agent
-- `:configure` configures the agent using the `kickstart` defaut commandline arguments.
+- `:configure` configures the agent using the `kickstart` default commandline arguments.
 
 The default `:configure` action is equivalent to the following
 **System Preferences > Sharing** settings:

--- a/documentation/resource_ard.md
+++ b/documentation/resource_ard.md
@@ -1,14 +1,14 @@
 ard
 ===
 
-Use the **ard** resource to manage the "Remote Management" settings, found in System
-Preferences > Sharing > Remote Management. Under the hood, an **ard** resource
+Use the [**ard**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/ard.rb) resource to manage the "Remote Management" settings, found in System
+Preferences > Sharing > Remote Management. Under the hood, the **ard** resource
 executes the `kickstart` command, located in ARDAgent.app (one of macOS' "core services").
 
 Syntax
 ------
 
-An **ard** resource block declares a basic description of the command configuration
+The **ard** resource block declares a basic description of the command configuration
 and a set of properties depending on the actions executed. For example:
 
 ```ruby

--- a/documentation/resource_certificate.md
+++ b/documentation/resource_certificate.md
@@ -1,13 +1,9 @@
 certificate
 =========
 
-Use the **certificate** resource to manage certificates for keychains.
-Under the hood, a **certificate** resource executes the `security`
+Use the [**certificate**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/certificate.rb) resource to manage certificates for keychains.
+Under the hood, the **certificate** resource executes the `security`
 command in the `security_cmd` library.
-
-[Learn more about certificates](https://developer.apple.com/library/content/documentation/Security/Conceptual/cryptoservices/KeyManagementAPIs/KeyManagementAPIs.html).
-
-[Learn more about `security`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/security.1.html).
 
 Syntax
 ------

--- a/documentation/resource_certificate.md
+++ b/documentation/resource_certificate.md
@@ -1,15 +1,15 @@
 certificate
 =========
 
-Use the [**certificate**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/certificate.rb) resource to manage certificates for keychains.
-Under the hood, the **certificate** resource executes the `security`
+Use the **certificate** resource to manage certificates for keychains.
+Under the hood, the [**certificate**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/certificate.rb) resource executes the `security`
 command in the `security_cmd` library.
 
 Syntax
 ------
 
 The full syntax for all of the properties available to the **certificate** resource
-are:
+is:
 
 ```ruby
 certificate 'cert name' do

--- a/documentation/resource_certificate.md
+++ b/documentation/resource_certificate.md
@@ -9,7 +9,7 @@ Syntax
 ------
 
 The full syntax for all of the properties available to the **certificate** resource
-is:
+are:
 
 ```ruby
 certificate 'cert name' do

--- a/documentation/resource_keychain.md
+++ b/documentation/resource_keychain.md
@@ -1,19 +1,15 @@
 keychain
 =========
 
-Use the **keychain** resource to manage keychains.
-Under the hood, a **keychain** resource executes the `security`
+Use the [**keychain**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/keychain.rb) resource to manage keychains.
+Under the hood, the **keychain** resource executes the `security`
 command in the `security_cmd` library.
-
-[Learn more about keychains](https://support.apple.com/kb/PH20093?locale=en_US).
-
-[Learn more about `security`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/security.1.html).
 
 Syntax
 ------
 
 The full syntax for all of the properties available to the **keychain** resource
-is:
+are:
 
 ```ruby
 keychain 'keychain name' do
@@ -33,19 +29,19 @@ the `keychain` property. This is the default action.
 `:delete`
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Delete a keychain as specified by
-the `keychain` property. 
+the `keychain` property.
 
 `:lock`
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Lock a keychain as specified by
-the `keychain` property. If no keychain is specified, the default keychain 
-will be locked instead. 
+the `keychain` property. If no keychain is specified, the default keychain
+will be locked instead.
 
 `:unlock`
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Using the `kc_passwd` property, unlock a 
-keychain as specified by the `keychain` property. If no keychain is specified, 
-the default keychain will be unlocked instead. 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Using the `kc_passwd` property, unlock a
+keychain as specified by the `keychain` property. If no keychain is specified,
+the default keychain will be unlocked instead.
 
 
 

--- a/documentation/resource_keychain.md
+++ b/documentation/resource_keychain.md
@@ -1,15 +1,15 @@
 keychain
 =========
 
-Use the [**keychain**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/keychain.rb) resource to manage keychains.
-Under the hood, the **keychain** resource executes the `security`
+Use the **keychain** resource to manage keychains.
+Under the hood, the [**keychain**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/keychain.rb) resource executes the `security`
 command in the `security_cmd` library.
 
 Syntax
 ------
 
 The full syntax for all of the properties available to the **keychain** resource
-are:
+is:
 
 ```ruby
 keychain 'keychain name' do

--- a/documentation/resource_machine_name.md
+++ b/documentation/resource_machine_name.md
@@ -1,7 +1,7 @@
 machine_name
 ============
 
-Use the **machine_name** resource to manage a machine's name. In theory, the
+Use the [**machine_name**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/machine_name.rb) resource to manage a machine's name. In theory, the
 `machine_name` resource should yield the same results that setting the
 **Computer Name** field in System Preferences would.
 
@@ -34,7 +34,7 @@ which would set:
 - `HostName` to **Johnnys-MacBookPro**
 
 The full syntax for all of the properties that are available to the **machine_name**
-resource is:
+resource are:
 
 ```ruby
 machine_name 'description' do

--- a/documentation/resource_machine_name.md
+++ b/documentation/resource_machine_name.md
@@ -12,7 +12,7 @@ A `dns_domain` property can be optionally specified. This will be tacked on to t
 end of the specified `hostname` property to form a fully-qualified domain name
 that the system `HostName` will be set to.
 
-When the state of a `machine_name` resource changes, an `ohai` resource is notified
+When the state of the `machine_name` resource changes, an `ohai` resource is notified
 to reload; this is so that all name changes are reflected and immediately available
 via the node's normal attributes. Additionally, regardless of the chosen `ComputerName`,
 both `HostName` and `LocalHostName` will be formatted to adhere to [RFC 1034](https://tools.ietf.org/html/rfc1034).
@@ -34,7 +34,7 @@ which would set:
 - `HostName` to **Johnnys-MacBookPro**
 
 The full syntax for all of the properties that are available to the **machine_name**
-resource are:
+resource is:
 
 ```ruby
 machine_name 'description' do

--- a/documentation/resource_macos_user.md
+++ b/documentation/resource_macos_user.md
@@ -1,15 +1,15 @@
 macos_user
 =========
 
-Use the [**macos_user**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/macos_user.rb) resource to manage user creation.
-Under the hood, the **macos_user** resource executes the `sysadminctl`
+Use the **macos_user** resource to manage user creation.
+Under the hood, the [**macos_user**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/macos_user.rb) resource executes the `sysadminctl`
 command.
 
 Syntax
 ------
 
 The full syntax for all of the properties available to the **macos_user** resource
-are:
+is:
 
 ```ruby
 macos_user 'user and action description' do

--- a/documentation/resource_macos_user.md
+++ b/documentation/resource_macos_user.md
@@ -1,15 +1,15 @@
 macos_user
 =========
 
-Use the **macos_user** resource to manage user creation.
-Under the hood, a **macos_user** resource executes the `sysadminctl`
+Use the [**macos_user**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/macos_user.rb) resource to manage user creation.
+Under the hood, the **macos_user** resource executes the `sysadminctl`
 command.
 
 Syntax
 ------
 
 The full syntax for all of the properties available to the **macos_user** resource
-is:
+are:
 
 ```ruby
 macos_user 'user and action description' do
@@ -46,7 +46,7 @@ Actions
 `:delete`
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Delete a user specified by
-the `macos_user` username property. 
+the `macos_user` username property.
 
 
 Examples

--- a/documentation/resource_plist.md
+++ b/documentation/resource_plist.md
@@ -1,7 +1,7 @@
 plist
 =====
 
-Use the **plist** resource to manage property list files (plists) and their content.
+Use the [**plist**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/plist.rb) resource to manage property list files (plists) and their content.
 A **plist** resource instance represents the state of a single key-value pair in
 the delared plist `path`. Since each plist resource instance represents only one
 setting, you may end up with several plist resource calls in a given recipe. Although
@@ -13,18 +13,16 @@ before changing any values. It also makes sure that the plist is in binary forma
 so that the settings can be interpreted correctly by the operating system.
 
 Prior knowledge of using commandline utilities such as
-[defaults](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/defaults.1.html),
-[plutil](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/plutil.1.html),
-and [PlistBuddy](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/PlistBuddy.8.html)
+`defaults`,
+`plutil`,
+and `PlistBuddy`
 will be useful when implementing the **plist** resource.
-
-Want to learn more? See the [Property List Programming Guide](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/PropertyLists/QuickStartPlist/QuickStartPlist.html#//apple_ref/doc/uid/10000048i-CH4-SW5).
 
 Syntax
 ------
 
 The full syntax for all of the properties that are available to the **plist**
-resource is:
+resource are:
 
 ```ruby
 plist 'description' do

--- a/documentation/resource_plist.md
+++ b/documentation/resource_plist.md
@@ -1,8 +1,8 @@
 plist
 =====
 
-Use the [**plist**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/plist.rb) resource to manage property list files (plists) and their content.
-A **plist** resource instance represents the state of a single key-value pair in
+Use the **plist** resource to manage property list files (plists) and their content.
+The [**plist**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/plist.rb) resource instance represents the state of a single key-value pair in
 the delared plist `path`. Since each plist resource instance represents only one
 setting, you may end up with several plist resource calls in a given recipe. Although
 this may seem like overkill, it allows us to have a fully idempotent resource with
@@ -22,7 +22,7 @@ Syntax
 ------
 
 The full syntax for all of the properties that are available to the **plist**
-resource are:
+resource is:
 
 ```ruby
 plist 'description' do

--- a/documentation/resource_spotlight.md
+++ b/documentation/resource_spotlight.md
@@ -1,19 +1,15 @@
 spotlight
 =========
 
-Use the **spotlight** resource to manage the metadata indexing state for disk volumes.
+Use the [**spotlight**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/spotlight.rb) resource to manage the metadata indexing state for disk volumes.
 This will primarily affect the ability to search volume contents with the macOS
-Spotlight feature. Under the hood, a **spotlight** resource executes the `mdutil`
+Spotlight feature. Under the hood, the **spotlight** resource executes the `mdutil`
 command in the `metadata_util` library.
-
-[Learn more about Spotlight](https://support.apple.com/en-us/HT204014).
-
-[Learn more about `mdutil`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/mdutil.1.html).
 
 Syntax
 ------
 
-The most basic usage of a **spotlight** resource block declares a disk volume as
+The most basic usage of the **spotlight** resource block declares a disk volume as
 the name property to **enable** metadata indexing:
 
 ```ruby
@@ -21,7 +17,7 @@ spotlight '/'
 ```
 
 The full syntax for all of the properties available to the **spotlight** resource
-is:
+are:
 
 ```ruby
 spotlight 'volume name' do

--- a/documentation/resource_spotlight.md
+++ b/documentation/resource_spotlight.md
@@ -1,9 +1,9 @@
 spotlight
 =========
 
-Use the [**spotlight**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/spotlight.rb) resource to manage the metadata indexing state for disk volumes.
+Use the **spotlight** resource to manage the metadata indexing state for disk volumes.
 This will primarily affect the ability to search volume contents with the macOS
-Spotlight feature. Under the hood, the **spotlight** resource executes the `mdutil`
+Spotlight feature. Under the hood, the [**spotlight**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/spotlight.rb) resource executes the `mdutil`
 command in the `metadata_util` library.
 
 Syntax
@@ -17,7 +17,7 @@ spotlight '/'
 ```
 
 The full syntax for all of the properties available to the **spotlight** resource
-are:
+is:
 
 ```ruby
 spotlight 'volume name' do

--- a/documentation/resource_xcode.md
+++ b/documentation/resource_xcode.md
@@ -1,8 +1,8 @@
 xcode
 =====
 
-Use the **xcode** resource to manage a single installation of Apple's Xcode IDE.
-An **xcode** resource instance represents the state of a single Xcode installation
+Use the [**xcode**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/xcode.rb) resource to manage a single installation of Apple's Xcode IDE.
+The **xcode** resource instance represents the state of a single Xcode installation
 and any additional iOS simulators that are declared using the `ios_simulators`
 property. The latest version of iOS simulators are always installed with Xcode.
 This resource supports beta and GM seeds from Apple if currently available via
@@ -15,7 +15,7 @@ path, overwriting an existing bundle if it is not the requested version.
 Syntax
 ------
 
-The simplest use of an **xcode** resource is:
+The simplest use of the **xcode** resource is:
 
 ```ruby
 xcode '9.4.1'
@@ -24,7 +24,7 @@ xcode '9.4.1'
 which would install Xcode 9.4.1 with the included iOS simulators.
 
 The full syntax for all of the properties that are available to the **xcode**
-resource is:
+resource are:
 
 ```ruby
 xcode 'description' do

--- a/documentation/resource_xcode.md
+++ b/documentation/resource_xcode.md
@@ -1,8 +1,8 @@
 xcode
 =====
 
-Use the [**xcode**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/xcode.rb) resource to manage a single installation of Apple's Xcode IDE.
-The **xcode** resource instance represents the state of a single Xcode installation
+Use the **xcode** resource to manage a single installation of Apple's Xcode IDE.
+The [**xcode**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/xcode.rb) resource instance represents the state of a single Xcode installation
 and any additional iOS simulators that are declared using the `ios_simulators`
 property. The latest version of iOS simulators are always installed with Xcode.
 This resource supports beta and GM seeds from Apple if currently available via
@@ -24,7 +24,7 @@ xcode '9.4.1'
 which would install Xcode 9.4.1 with the included iOS simulators.
 
 The full syntax for all of the properties that are available to the **xcode**
-resource are:
+resource is:
 
 ```ruby
 xcode 'description' do


### PR DESCRIPTION
This PR removes the links to outdated apple documentation in each resource documentation, and adds links to each resource that is being defined in the documentation.