### PR TITLE
Add dependency on chef-sugar cookbook to provide platform helper methods

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,3 +11,5 @@ source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'
 
 supports 'mac_os_x'
+
+depends 'chef-sugar'

--- a/recipes/xcode.rb
+++ b/recipes/xcode.rb
@@ -1,11 +1,11 @@
-if node['platform_version'].match? Regexp.union /10.14|10.13/
+if mac_os_x_after_sierra?
   execute 'Disable Gatekeeper' do
     command ['spctl', '--master-disable']
   end
 
   xcode node['macos']['xcode']['version']
 
-elsif node['platform_version'].match? Regexp.union '10.12'
+elsif mac_os_x_sierra?
   execute 'Disable Gatekeeper' do
     command ['spctl', '--master-disable']
   end
@@ -13,4 +13,7 @@ elsif node['platform_version'].match? Regexp.union '10.12'
   xcode '9.2' do
     ios_simulators %w(11 10)
   end
+
+else
+  raise "macOS #{node['platform_version']} is not supported."
 end


### PR DESCRIPTION
This allows us to utilize sugar like:
- `mac_os_x?`
- `virtual?`
- `mac_os_x_before_or_at_maverick?`