### PR TITLE
 Add dependency on chef-sugar cookbook to provide platform helper methods

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ issues_url 'https://github.com/Microsoft/macos-cookbook/issues'
 
 supports 'mac_os_x'
 
-depends 'chef-sugar'
+depends 'chef-sugar', '~> 4.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,3 +11,5 @@ source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'
 
 supports 'mac_os_x'
+
+depends 'chef-sugar'

--- a/recipes/xcode.rb
+++ b/recipes/xcode.rb
@@ -1,11 +1,11 @@
-if node['platform_version'].match? Regexp.union /10.14|10.13/
+if mac_os_x_after_sierra?
   execute 'Disable Gatekeeper' do
     command ['spctl', '--master-disable']
   end
 
   xcode node['macos']['xcode']['version']
 
-elsif node['platform_version'].match? Regexp.union '10.12'
+elsif mac_os_x_sierra?
   execute 'Disable Gatekeeper' do
     command ['spctl', '--master-disable']
   end

--- a/recipes/xcode.rb
+++ b/recipes/xcode.rb
@@ -14,8 +14,11 @@ elsif mac_os_x_sierra?
     ios_simulators %w(11 10)
   end
 
-elsif node['platform_version'].match? Regexp.union '10.11'
+elsif mac_os_x_el_capitan?
   xcode '8.2.1' do
     ios_simulators %w(10 9)
   end
+
+else
+  raise "#{node['platform_version']} is not supported."
 end


### PR DESCRIPTION
This allows us to utilize sugar like:
- `mac_os_x?`
- `virtual?`
- `mac_os_x_before_or_at_maverick?`