### PR TITLE
Fix for Issue #163

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,14 +62,14 @@ platforms:
 - name: mojave-chef13
   driver:
     box: microsoft/macos-mojave
-    version: 10.14.01
+    version: 10.14.1
   provisioner:
     product_version: 13
 
 - name: mojave-chef14
   driver:
     box: microsoft/macos-mojave
-    version: 10.14.01
+    version: 10.14.1
   provisioner:
     product_version: 14
 

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -11,6 +11,8 @@ module MacOS
 
       @version = if available.empty?
                    'Unavailable from Software Update Catalog'
+                 elsif platform_specific.empty?
+                   'Absent from Software Update Catalog'
                  else
                    latest.tr('*', '').strip
                  end

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -10,7 +10,7 @@ module MacOS
       FileUtils.chown 'root', 'wheel', install_sentinel
 
       @version = if available.empty?
-                   'Unavailable from Software Update Catalog'
+                   'No Command Lines Tools available from Software Update Catalog!'
                  elsif platform_specific.empty?
                    'Absent from Software Update Catalog'
                  else

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -12,7 +12,7 @@ module MacOS
       @version = if available.empty?
                    'No Command Lines Tools available from Software Update Catalog!'
                  elsif platform_specific.empty?
-                   'Absent from Software Update Catalog'
+                   "No Command Line Tools specific to #{macos_version} available from Software Update Catalog!"
                  else
                    latest.tr('*', '').strip
                  end

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -52,7 +52,7 @@ describe MacOS::CommandLineTools do
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
-      expect(clt.version).to eq 'Absent from Software Update Catalog'
+      expect(clt.version).to eq 'No Command Line Tools specific to 10.14 available from Software Update Catalog!
     end
   end
 

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -30,6 +30,32 @@ describe MacOS::CommandLineTools do
     end
   end
 
+  context 'when provided an incomplete list of software update products in Mojave' do
+    before do
+      allow(FileUtils).to receive(:touch).and_return(true)
+      allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+        .and_return('10.14')
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "\n", "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "   * Command Line Tools (macOS El Capitan version 10.11) for Xcode-8.2\n",
+                     "\tCommand Line Tools (macOS El Capitan version 10.11) for Xcode (8.2), 150374K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (10.0), 190520K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
+                     "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
+                   )
+    end
+    it 'returns the latest recommended Command Line Tools product' do
+      clt = MacOS::CommandLineTools.new
+      expect(clt.version).to eq 'Absent from Software Update Catalog'
+    end
+  end
+
   context 'when provided an available list of software update products in High Sierra' do
     before do
       allow(FileUtils).to receive(:touch).and_return(true)

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -52,7 +52,7 @@ describe MacOS::CommandLineTools do
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
-      expect(clt.version).to eq 'No Command Line Tools specific to 10.14 available from Software Update Catalog!
+      expect(clt.version).to eq 'No Command Line Tools specific to 10.14 available from Software Update Catalog!'
     end
   end
 


### PR DESCRIPTION
### Problem
When the Software Update Catalog provides an incomplete list (such as Mojave command line tools missing), the `tr` operator is performed on a nil object resulting in a converge failure. 

### Fix
Handling the case with a check for `platform_specific.empty?` and producing an appropriate error message should be sufficient when assigning the `version` variable. 

### Test
Spec test mocking an incomplete Software Update Catalog output and checking that the check mentioned above generates the appropriate error message. 