### PR TITLE
Master branch only build branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 macOS Cookbook
 ==============
 
-[![Build status](https://dev.azure.com/office/APEX/_apis/build/status/lab/cookbooks/macos)](https://dev.azure.com/office/APEX/_build/latest?definitionId=2143)
+[![Build status](https://dev.azure.com/office/APEX/_apis/build/status/lab/cookbooks/macos?branchName=master)](https://dev.azure.com/office/APEX/_build/latest?definitionId=2143)
 
 Chef resources and recipes for managing and provisioning macOS.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 macOS Cookbook
 ==============
 
-![build-status-badge](https://office.visualstudio.com/_apis/public/build/definitions/59d72877-1cea-4eb6-9d06-66716573631a/2791/badge)
+[![Build status](https://dev.azure.com/office/APEX/_apis/build/status/lab/cookbooks/macos)](https://dev.azure.com/office/APEX/_build/latest?definitionId=2143)
 
 Chef resources and recipes for managing and provisioning macOS.
 


### PR DESCRIPTION
This PR makes the build badge reflect the state of the master branch only so that we can have nightly builds on master without worrying about the build badge reflecting the build results of feature or release branches. 