### PR TITLE
Remove hard-coded path for xcode-install gem

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -121,17 +121,6 @@ suites:
     - xcode-and-simulators
     - command-line-tool-sentinel
 
-- name: xcode-chefdk
-  run_list:
-  - recipe[macos_test::xcode]
-  verifier:
-    controls:
-    - xcode-and-simulators
-    - command-line-tool-sentinel
-  provisioner:
-    product_name: chefdk
-    product_version: 3
-
 - name: certificate
   run_list:
   - recipe[macos_test::certificate]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -121,6 +121,17 @@ suites:
     - xcode-and-simulators
     - command-line-tool-sentinel
 
+- name: xcode-chefdk
+  run_list:
+  - recipe[macos_test::xcode]
+  verifier:
+    controls:
+    - xcode-and-simulators
+    - command-line-tool-sentinel
+  provisioner:
+    product_name: chefdk
+    product_version: 3
+
 - name: certificate
   run_list:
   - recipe[macos_test::certificate]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [2.8.1] - 2018-11-29
+### Fixed
+- Fixed an issue where the path for the `xcversion` utility was hard-coded when installed as a Chef gem, which caused failures when converging with ChefDK or Workstation.
+
 ## [2.8.0] - 2018-11-14
 ### Added
 - Sugar helps the code go down! We now depend on [Chef Sugar](https://supermarket.chef.io/tools/chef-sugar) for `mac_os_x?`, `virtual?`, `mac_os_x_before_or_at_maverick?`, etc.

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -3,8 +3,8 @@ include Chef::Mixin::ShellOut
 module MacOS
   module XCVersion
     class << self
-      def xcversion
-        '/opt/chef/embedded/bin/xcversion '.freeze
+      def xcversion_path
+        Chef::Util::PathHelper.join(Chef::Config.embedded_dir, 'bin', 'xcversion')
       end
 
       def update

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -27,12 +27,16 @@ module MacOS
         xcversion 'list'
       end
 
+      def list_installed_xcodes
+        xcversion 'installed'
+      end
+
       def install_xcode(xcode)
         xcversion "install '#{xcode.version}'"
       end
 
       def installed_xcodes
-        lines = shell_out(xcversion + 'installed').stdout.lines
+        lines = shell_out(XCVersion.list_installed_xcodes).stdout.lines
         lines.map { |line| { line.split.first => line.split.last.delete('()') } }
       end
 

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -7,24 +7,28 @@ module MacOS
         Chef::Util::PathHelper.join(Chef::Config.embedded_dir, 'bin', 'xcversion')
       end
 
+      def xcversion(command)
+        [xcversion_path, command].join(' ')
+      end
+
       def update
-        xcversion + 'update'
+        xcversion 'update'
       end
 
       def list_simulators
-        xcversion + 'simulators'
+        xcversion 'simulators'
       end
 
       def install_simulator(simulator)
-        xcversion + "simulators --install='#{simulator.version}'"
+        xcversion "simulators --install='#{simulator.version}'"
       end
 
-      def list_xcodes
-        xcversion + 'list'
+      def list_available_xcodes
+        xcversion 'list'
       end
 
       def install_xcode(xcode)
-        xcversion + "install '#{xcode.version}'"
+        xcversion "install '#{xcode.version}'"
       end
 
       def installed_xcodes

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -23,12 +23,12 @@ module MacOS
         xcversion "simulators --install='#{simulator.version}'"
       end
 
-      def list_available_xcodes
-        xcversion 'list'
-      end
-
       def list_installed_xcodes
         xcversion 'installed'
+      end
+
+      def list_available_xcodes
+        xcversion 'list'
       end
 
       def install_xcode(xcode)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -41,7 +41,7 @@ module MacOS
       end
 
       def available_versions
-        shell_out!(XCVersion.list_xcodes).stdout.lines
+        shell_out!(XCVersion.list_available_xcodes).stdout.lines
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.8.0'
+version '2.8.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'


### PR DESCRIPTION
## [2.8.1] - 2018-11-29
### Fixed
- Fixed an issue where the path for the `xcversion` utility was hard-coded when installed as a Chef gem, which caused failures when converging with ChefDK or Workstation.

Resolves #168.