### PR TITLE
Add support for owner/group to plist resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -85,6 +85,7 @@ suites:
     - dock-appearance
     - show-all-files
     - updates-disabled
+    - plist-creation
 
 - name: power-management
   provisioner:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 ## [2.9.0] - 2018-12-06
 ### Added
 - Added templates for bug reports, feature requests, and pull requests to adhere to adhere with Github's [recommended community standards](https://opensource.guide). 
+- Adds support for owner/group in the plist resource. Allows for plist files to be created under a specific owner. Defaults to root/wheel for compatablity with earlier versions of the cookbook.
 
 ## [2.8.1] - 2018-11-29
 ### Fixed

--- a/documentation/resource_plist.md
+++ b/documentation/resource_plist.md
@@ -31,6 +31,8 @@ plist 'description' do
   value                        TrueClass, FalseClass, String, Integer, Float
   action                       Symbol # defaults to :set if not specified
   encoding                     String # defaults to 'binary' if not specified.
+  owner                        String # defaults to 'root' if not specified.
+  group                        String # defaults to 'wheel' if not specified.
 end
 ```
 

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -72,7 +72,7 @@ action :set do
     end
   end
 
-  converge_if_change :group do
+  converge_if_changed :group do
     converge_by "update group to #{new_resource.group}" do
       file new_resource.path do
         group new_resource.group

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -6,6 +6,7 @@ property :value, [TrueClass, FalseClass, String, Integer, Float], desired_state:
 property :encoding, String, desired_state: true, default: 'binary'
 property :owner, String, desired_state: true, default: 'root'
 property :group, String, desired_state: true, default: 'wheel'
+property :mode, [String, Integer]
 
 load_current_value do |desired|
   current_value_does_not_exist! unless ::File.exist? desired.path
@@ -32,6 +33,7 @@ action :set do
         content empty_plist
         owner new_resource.owner
         group new_resource.group
+        mode new_resource.mode if property_is_set?(:mode)
       end
     end
   end

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -64,7 +64,7 @@ action :set do
     end
   end
 
-  converge_if_change :owner do
+  converge_if_changed :owner do
     converge_by "update owner to #{new_resource.owner}" do
       file new_resource.path do
         owner new_resource.owner

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -28,7 +28,8 @@ action :set do
   converge_if_changed :path do
     converge_by "create new plist: '#{new_resource.path}'" do
       file new_resource.path do
-        content {}.to_plist
+        empty_plist = {}.to_plist
+        content empty_plist
         owner new_resource.owner
         group new_resource.group
       end

--- a/test/cookbooks/macos_test/recipes/preferences.rb
+++ b/test/cookbooks/macos_test/recipes/preferences.rb
@@ -2,16 +2,40 @@ plist 'show hidden files' do
   path '/Users/vagrant/Library/Preferences/com.apple.finder.plist'
   entry 'AppleShowAllFiles'
   value true
+  owner 'vagrant'
+  group 'staff'
 end
 
 plist 'put the Dock on the left side' do
   path '/Users/vagrant/Library/Preferences/com.apple.dock.plist'
   entry 'orientation'
   value 'left'
+  owner 'vagrant'
+  group 'staff'
 end
 
 plist 'disable window animations and Get Info animations' do
   path '/Users/vagrant/Library/Preferences/com.apple.dock.plist'
   entry 'DisableAllAnimations'
   value true
+  owner 'vagrant'
+  group 'staff'
+end
+
+plist 'create a plist that does not exist to test plist creation' do
+  path '/Users/vagrant/com.microsoft.macoscookbook.plist'
+  entry 'PokeballEatenByDog'
+  value true
+  owner 'vagrant'
+  group 'staff'
+  encoding 'ascii'
+end
+
+plist 'add another value to the new plist' do
+  path '/Users/vagrant/com.microsoft.macoscookbook.plist'
+  entry 'CaughtEmAll'
+  value false
+  owner 'vagrant'
+  group 'staff'
+  encoding 'ascii'
 end

--- a/test/cookbooks/macos_test/recipes/preferences.rb
+++ b/test/cookbooks/macos_test/recipes/preferences.rb
@@ -1,5 +1,5 @@
-dock_plist = "/Users/vagrant/Library/Preferences/com.apple.dock.plist"
-macoscookbook_plist = "/Users/vagrant/com.microsoft.macoscookbook.plist"
+dock_plist = '/Users/vagrant/Library/Preferences/com.apple.dock.plist'
+macoscookbook_plist = '/Users/vagrant/com.microsoft.macoscookbook.plist'
 
 plist 'show hidden files' do
   path '/Users/vagrant/Library/Preferences/com.apple.finder.plist'

--- a/test/cookbooks/macos_test/recipes/preferences.rb
+++ b/test/cookbooks/macos_test/recipes/preferences.rb
@@ -1,5 +1,5 @@
-dock = "/Users/vagrant/Library/Preferences/com.apple.dock.plist"
-macoscookbook = "/Users/vagrant/com.microsoft.macoscookbook.plist"
+dock_plist = "/Users/vagrant/Library/Preferences/com.apple.dock.plist"
+macoscookbook_plist = "/Users/vagrant/com.microsoft.macoscookbook.plist"
 
 plist 'show hidden files' do
   path '/Users/vagrant/Library/Preferences/com.apple.finder.plist'
@@ -10,7 +10,7 @@ plist 'show hidden files' do
 end
 
 plist 'put the Dock on the left side' do
-  path dock
+  path dock_plist
   entry 'orientation'
   value 'left'
   owner 'vagrant'
@@ -18,7 +18,7 @@ plist 'put the Dock on the left side' do
 end
 
 plist 'disable window animations and Get Info animations' do
-  path dock
+  path dock_plist
   entry 'DisableAllAnimations'
   value true
   owner 'vagrant'
@@ -26,7 +26,7 @@ plist 'disable window animations and Get Info animations' do
 end
 
 plist 'create a plist that does not exist to test plist creation' do
-  path macoscookbook
+  path macoscookbook_plist
   entry 'PokeballEatenByDog'
   value true
   owner 'vagrant'
@@ -35,7 +35,7 @@ plist 'create a plist that does not exist to test plist creation' do
 end
 
 plist 'add another value to the new plist' do
-  path macoscookbook
+  path macoscookbook_plist
   entry 'CaughtEmAll'
   value false
   owner 'vagrant'

--- a/test/cookbooks/macos_test/recipes/preferences.rb
+++ b/test/cookbooks/macos_test/recipes/preferences.rb
@@ -1,3 +1,6 @@
+dock = "/Users/vagrant/Library/Preferences/com.apple.dock.plist"
+macoscookbook = "/Users/vagrant/com.microsoft.macoscookbook.plist"
+
 plist 'show hidden files' do
   path '/Users/vagrant/Library/Preferences/com.apple.finder.plist'
   entry 'AppleShowAllFiles'
@@ -7,7 +10,7 @@ plist 'show hidden files' do
 end
 
 plist 'put the Dock on the left side' do
-  path '/Users/vagrant/Library/Preferences/com.apple.dock.plist'
+  path dock
   entry 'orientation'
   value 'left'
   owner 'vagrant'
@@ -15,7 +18,7 @@ plist 'put the Dock on the left side' do
 end
 
 plist 'disable window animations and Get Info animations' do
-  path '/Users/vagrant/Library/Preferences/com.apple.dock.plist'
+  path dock
   entry 'DisableAllAnimations'
   value true
   owner 'vagrant'
@@ -23,7 +26,7 @@ plist 'disable window animations and Get Info animations' do
 end
 
 plist 'create a plist that does not exist to test plist creation' do
-  path '/Users/vagrant/com.microsoft.macoscookbook.plist'
+  path macoscookbook
   entry 'PokeballEatenByDog'
   value true
   owner 'vagrant'
@@ -32,7 +35,7 @@ plist 'create a plist that does not exist to test plist creation' do
 end
 
 plist 'add another value to the new plist' do
-  path '/Users/vagrant/com.microsoft.macoscookbook.plist'
+  path macoscookbook
   entry 'CaughtEmAll'
   value false
   owner 'vagrant'

--- a/test/cookbooks/macos_test/recipes/preferences.rb
+++ b/test/cookbooks/macos_test/recipes/preferences.rb
@@ -31,7 +31,7 @@ plist 'create a plist that does not exist to test plist creation' do
   value true
   owner 'vagrant'
   group 'staff'
-  encoding 'ascii'
+  encoding 'us-ascii'
 end
 
 plist 'add another value to the new plist' do
@@ -40,5 +40,5 @@ plist 'add another value to the new plist' do
   value false
   owner 'vagrant'
   group 'staff'
-  encoding 'ascii'
+  encoding 'us-ascii'
 end

--- a/test/cookbooks/macos_test/recipes/preferences.rb
+++ b/test/cookbooks/macos_test/recipes/preferences.rb
@@ -32,6 +32,7 @@ plist 'create a plist that does not exist to test plist creation' do
   owner 'vagrant'
   group 'staff'
   encoding 'us-ascii'
+  mode '0600'
 end
 
 plist 'add another value to the new plist' do

--- a/test/integration/default/controls/dock_test.rb
+++ b/test/integration/default/controls/dock_test.rb
@@ -13,4 +13,9 @@ control 'dock-appearance' do
   describe command("/usr/libexec/PlistBuddy -c 'Print :DisableAllAnimations' #{user_home}/Library/Preferences/com.apple.dock.plist") do
     its('stdout') { should match 'true' }
   end
+
+  describe file("#{user_home}/Library/Preferences/com.apple.dock.plist") do
+    its('owner') { should eq 'vagrant' }
+    its('group') { should eq 'staff' }
+  end
 end

--- a/test/integration/default/controls/general_test.rb
+++ b/test/integration/default/controls/general_test.rb
@@ -10,4 +10,29 @@ control 'show-all-files' do
   describe command("/usr/libexec/PlistBuddy -c 'Print :AppleShowAllFiles' #{finder_plist}") do
     its('stdout') { should match 'true' }
   end
+
+  describe file(finder_plist) do
+    its('owner') { should eq 'vagrant' }
+    its('group') { should eq 'staff' }
+  end
+end
+
+control 'plist-creation' do
+  title 'arbitrary plist creation'
+  desc 'creation and modification of a property list'
+
+  macos_cookbook_plist = '/Users/vagrant/com.microsoft.macoscookbook.plist'
+
+  describe command("/usr/libexec/PlistBuddy -c 'Print :PokeballEatenByDog' #{macos_cookbook_plist}") do
+    its('stdout') { should match 'true' }
+  end
+
+  describe command("/usr/libexec/PlistBuddy -c 'Print :CaughtEmAll' #{macos_cookbook_plist}") do
+    its('stdout') { should match 'false' }
+  end
+
+  describe file(macos_cookbook_plist) do
+    its('owner') { should eq 'vagrant' }
+    its('group') { should eq 'staff' }
+  end
 end

--- a/test/integration/default/controls/general_test.rb
+++ b/test/integration/default/controls/general_test.rb
@@ -14,6 +14,7 @@ control 'show-all-files' do
   describe file(finder_plist) do
     its('owner') { should eq 'vagrant' }
     its('group') { should eq 'staff' }
+    its('mode') { should eq '0600' }
   end
 end
 
@@ -34,5 +35,6 @@ control 'plist-creation' do
   describe file(macos_cookbook_plist) do
     its('owner') { should eq 'vagrant' }
     its('group') { should eq 'staff' }
+    its('mode') { should eq '0600' }
   end
 end

--- a/test/integration/default/controls/general_test.rb
+++ b/test/integration/default/controls/general_test.rb
@@ -14,7 +14,7 @@ control 'show-all-files' do
   describe file(finder_plist) do
     its('owner') { should eq 'vagrant' }
     its('group') { should eq 'staff' }
-    its('mode') { should eq '0600' }
+    its('mode') { should cmp '0600' }
   end
 end
 
@@ -35,6 +35,6 @@ control 'plist-creation' do
   describe file(macos_cookbook_plist) do
     its('owner') { should eq 'vagrant' }
     its('group') { should eq 'staff' }
-    its('mode') { should eq '0600' }
+    its('mode') { should cmp '0600' }
   end
 end


### PR DESCRIPTION
- Paired with Andre Shields, Chris Gilbert, and Eric Hanko
- Adds support for owner/group to plist resource
- Allows for files to be created under a specific owner
- Fixes #51 

Fixes AB#2734644
