### PR TITLE
Bump chef-sugar version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,11 +5,11 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.9.0'
+version '2.9.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'
 
 supports 'mac_os_x'
 
-depends 'chef-sugar', '~> 4.1'
+depends 'chef-sugar', '~> 5.0'


### PR DESCRIPTION
This is for a downstream dependency in one of our internal cookbooks.