### PR TITLE
expect correct hash in kcpassword unit test

### DIFF
--- a/spec/unit/libraries/macos_user_spec.rb
+++ b/spec/unit/libraries/macos_user_spec.rb
@@ -10,8 +10,8 @@ describe MacOS::MacOSUserHelpers, '#kcpassword_hash' do
   end
 
   context 'When calling the obfuscate method on a long password' do
-    xit 'the password hash value matches the binary content of the file' do
-      expect(kcpassword_hash('correct-horse-battery-staple')).to eq "\x1E\xE6 Q\xB7\xDF\xA9\xC7\xCB\xD6m\x0E\xEC\x7FA\xB3\xC8\xA9\x8F\xD1\xC02\x0E\xFD3S\xBE\xD9\xAE\x9F\xC7\xD6\x1F".force_encoding('ASCII-8BIT')
+    it 'the password hash value matches the binary content of the file' do
+      expect(kcpassword_hash('correct-horse-battery-staple')).to eq "\x1E\xE6 Q\xB7\xDF\xA9\xC7\xCB\xD6m\x0E\xEC\x7FA\xB3\xC8\xA9\x8F\xD1\xC02\x0E\xFD3S\xBE\xD9\xDD\xEA\xA3\xB9\x1F".force_encoding('ASCII-8BIT')
     end
   end
 end


### PR DESCRIPTION
hash was originally for "correct-horse-battery-staplesudo".