### PR TITLE
Hotfix/2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.10.0] - 2019-01-29
+## [2.10.1] - 2019-01-29
 
 ### Fixed
 - Fixed issue in which setting certain `machine_name` resource properties (`hostname`, `local_hostname`, `dns_domain`) from a previously unset state, would fail to compile. ([Issue #181](https://github.com/Microsoft/macos-cookbook/issues/181)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [2.10.0] - 2018-01-16
+## [2.10.0] - 2019-01-29
+
+### Fixed
+- Fixed issue in which setting certain `machine_name` resource properties (`hostname`, `local_hostname`, `dns_domain`) from a previously unset state, would fail to compile. ([Issue #181](https://github.com/Microsoft/macos-cookbook/issues/181)).
+
+## [2.10.0] - 2019-01-16
 
 ### Added
 

--- a/libraries/machine_name.rb
+++ b/libraries/machine_name.rb
@@ -10,7 +10,12 @@ module MacOS
       valid_names = %w(LocalHostName HostName ComputerName)
       Chef::Application.fatal! "Name type must be one of #{valid_names}. We got '#{name_type}'." unless valid_names.include? name_type
       command = shell_out scutil, '--get', name_type
-      command.stdout.chomp
+
+      if command.nil?
+        return ''
+      else
+        command.stdout.chomp
+      end
     end
 
     def current_hostname
@@ -18,6 +23,8 @@ module MacOS
     end
 
     def current_dns_domain
+      return '' if split_hostname.empty?
+
       dns_domain = split_hostname.length - 1
       split_hostname.last(dns_domain).join '.'
     end

--- a/libraries/machine_name.rb
+++ b/libraries/machine_name.rb
@@ -11,11 +11,7 @@ module MacOS
       Chef::Application.fatal! "Name type must be one of #{valid_names}. We got '#{name_type}'." unless valid_names.include? name_type
       command = shell_out scutil, '--get', name_type
 
-      if command.nil?
-        return ''
-      else
-        command.stdout.chomp
-      end
+      command.nil? ? '' : command.stdout.chomp
     end
 
     def current_hostname

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 13.0' if respond_to?(:chef_version)
-version '2.10.0'
+version '2.10.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/machine_name.rb
+++ b/resources/machine_name.rb
@@ -2,10 +2,10 @@ resource_name :machine_name
 
 deprecated 'The `machine_name` resource is deprecated, and will be removed in the release of v3.0 of the macOS cookbook.'
 
-property :hostname, String, desired_state: true, coerce: proc { |name| conform_to_dns_standards(name) }, name_property: true
+property :hostname, [String, nil], desired_state: true, coerce: proc { |name| conform_to_dns_standards(name) }, name_property: true
 property :computer_name, String, desired_state: true
-property :local_hostname, String, desired_state: true, coerce: proc { |name| conform_to_dns_standards(name) }
-property :dns_domain, String, desired_state: false
+property :local_hostname, [String, nil], desired_state: true, coerce: proc { |name| conform_to_dns_standards(name) }
+property :dns_domain, [String, nil], desired_state: false
 
 load_current_value do
   hostname current_hostname

--- a/test/cookbooks/macos_test/recipes/machine_name.rb
+++ b/test/cookbooks/macos_test/recipes/machine_name.rb
@@ -1,5 +1,9 @@
 washing_machine_name = 'New' + node['platform_version'] + '_Washing_Machine'
 
+execute 'setting hostname to nil' do
+  command 'sudo scutil --set HostName'
+end
+
 machine_name 'set computer/hostname' do
   hostname washing_machine_name
   computer_name washing_machine_name


### PR DESCRIPTION
## [2.10.0] - 2019-01-29

### Fixed
- Fixed issue in which setting certain `machine_name` resource properties (`hostname`, `local_hostname`, `dns_domain`) from a previously unset state, would fail to compile. ([Issue #181](https://github.com/Microsoft/macos-cookbook/issues/181)).