### PR TITLE
Correct documentation of xcode resource attribute key

### DIFF
--- a/documentation/resource_xcode.md
+++ b/documentation/resource_xcode.md
@@ -76,13 +76,13 @@ The `xcode` resource can utilize a `credentials` data bag with an `apple_id` dat
 }
 ```
 
-The `xcode` resource can also utilize an AppleID set (preferably at run-time for security) under the node attributes `node['macos']['apple_id']['apple_id']` and `node['macos']['apple_id']['password']`.
+The `xcode` resource can also utilize an AppleID set (preferably at run-time for security) under the node attributes `node['macos']['apple_id']['user']` and `node['macos']['apple_id']['password']`.
 
 **Example:**
 
 ```ruby
-node['macos']['apple_id']['apple_id'] = 'farva@spurbury.gov'
-node['macos']['apple_id']['password'] = '0k@yN0cR34m'
+node.normal['macos']['apple_id']['user'] = 'farva@spurbury.gov'
+node.normal['macos']['apple_id']['password'] = '0k@yN0cR34m'
 ```
 
 Examples

--- a/documentation/resource_xcode.md
+++ b/documentation/resource_xcode.md
@@ -76,13 +76,23 @@ The `xcode` resource can utilize a `credentials` data bag with an `apple_id` dat
 }
 ```
 
-The `xcode` resource can also utilize an AppleID set (preferably at run-time for security) under the node attributes `node['macos']['apple_id']['user']` and `node['macos']['apple_id']['password']`.
+The `xcode` resource can also utilize an AppleID set (preferably at run-time for
+security, and unset after use) under the node attributes
+`node['macos']['apple_id']['user']` and `node['macos']['apple_id']['password']`.
 
 **Example:**
 
 ```ruby
 node.normal['macos']['apple_id']['user'] = 'farva@spurbury.gov'
 node.normal['macos']['apple_id']['password'] = '0k@yN0cR34m'
+
+xcode '10.1'
+
+ruby_block 'Remove AppleID password attribute' do
+  block do
+    node.rm('macos', 'apple_id', 'password')
+  end
+end
 ```
 
 Examples


### PR DESCRIPTION
---
name: Correct documentation of xcode resource attribute key
about: Documentation correction and improvement.
title: "Correct documentation of xcode resource attribute key"
labels:
assignees:

---

## Describe the Pull Request  
This PR corrects an incorrect attribute key in the `xcode` resource documentation, and adds a security suggestion.

## Justification  
Should save developers following the documentation some time when AppleID authentication does not work. And remind developers to unset sensitive attribute values after use.