### PR TITLE
Do not set "Restart After Power Failure" preference on portables

### DIFF
--- a/recipes/keep_awake.rb
+++ b/recipes/keep_awake.rb
@@ -31,7 +31,7 @@ end
 system_preference 'restart after a power failure' do
   preference :restartpowerfailure
   setting 'On'
-  not_if { environment.vm? }
+  not_if { environment.vm? || form_factor.portable? }
 end
 
 system_preference 'pressing power button does not sleep computer' do

--- a/spec/unit/recipes/keep_awake_spec.rb
+++ b/spec/unit/recipes/keep_awake_spec.rb
@@ -42,9 +42,9 @@ shared_context 'when running on bare metal MacBook Pro' do
       expect(chef_run).to set_system_preference('wake the computer when accessed using a network connection')
     end
 
-    it 'sets restart after a power failure' do
+    it 'does not set restart after a power failure' do
       chef_run.converge(described_recipe)
-      expect(chef_run).to set_system_preference('restart after a power failure')
+      expect(chef_run).to_not set_system_preference('restart after a power failure')
     end
 
     it 'converges successfully on bare metal' do


### PR DESCRIPTION
---
name: Do not set "Restart After Power Failure" preference on portables
about: Do not try to set an invalid portables preference on portables.
title: "Do not set "Restart After Power Failure" preference on portables"
labels:
assignees:

---

## Describe the Pull Request  
This PR changes the `keep_awake` recipe to not set the "Restart After Power Failure" preference when running on portables, i.e. MacBooks.

## Justification  
The `keep_awake` recipe fails when running on a MacBook. The preference in question is not valid on portables. Trying to set it with `systemsetup` results in this error message:

> Restart After Power Failure: Not supported on this machine.