### PR TITLE
Release/3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## [3.0.1] - 2019-03-15
 
+Thanks to @jkronborg for these two fixes!
+
 ### Fixed
 - Fixed a guard in `keep_awake` for use on portables. 
 - Fixed incorrect attribute key in the Xcode resource documentation, and added a security suggestion. 
-
 ## [3.0.0] - 2019-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.1] - 2019-03-15
+
+### Fixed
+- Fixed a guard in `keep_awake` for use on portables. 
+- Fixed incorrect attribute key in the Xcode resource documentation, and added a security suggestion. 
+
 ## [3.0.0] - 2019-02-28
 
 ### Added

--- a/documentation/resource_xcode.md
+++ b/documentation/resource_xcode.md
@@ -76,13 +76,23 @@ The `xcode` resource can utilize a `credentials` data bag with an `apple_id` dat
 }
 ```
 
-The `xcode` resource can also utilize an AppleID set (preferably at run-time for security) under the node attributes `node['macos']['apple_id']['apple_id']` and `node['macos']['apple_id']['password']`.
+The `xcode` resource can also utilize an AppleID set (preferably at run-time for
+security, and unset after use) under the node attributes
+`node['macos']['apple_id']['user']` and `node['macos']['apple_id']['password']`.
 
 **Example:**
 
 ```ruby
-node['macos']['apple_id']['apple_id'] = 'farva@spurbury.gov'
-node['macos']['apple_id']['password'] = '0k@yN0cR34m'
+node.normal['macos']['apple_id']['user'] = 'farva@spurbury.gov'
+node.normal['macos']['apple_id']['password'] = '0k@yN0cR34m'
+
+xcode '10.1'
+
+ruby_block 'Remove AppleID password attribute' do
+  block do
+    node.rm('macos', 'apple_id', 'password')
+  end
+end
 ```
 
 Examples

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.0'
+version '3.0.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/recipes/keep_awake.rb
+++ b/recipes/keep_awake.rb
@@ -31,7 +31,7 @@ end
 system_preference 'restart after a power failure' do
   preference :restartpowerfailure
   setting 'On'
-  not_if { environment.vm? }
+  not_if { environment.vm? || form_factor.portable? }
 end
 
 system_preference 'pressing power button does not sleep computer' do

--- a/spec/unit/recipes/keep_awake_spec.rb
+++ b/spec/unit/recipes/keep_awake_spec.rb
@@ -42,9 +42,9 @@ shared_context 'when running on bare metal MacBook Pro' do
       expect(chef_run).to set_system_preference('wake the computer when accessed using a network connection')
     end
 
-    it 'sets restart after a power failure' do
+    it 'does not set restart after a power failure' do
       chef_run.converge(described_recipe)
-      expect(chef_run).to set_system_preference('restart after a power failure')
+      expect(chef_run).to_not set_system_preference('restart after a power failure')
     end
 
     it 'converges successfully on bare metal' do


### PR DESCRIPTION
## [3.0.1] - 2019-03-15

Thanks to @jkronborg for these two fixes!

### Fixed
- Fixed a guard in `keep_awake` for use on portables. 
- Fixed incorrect attribute key in the Xcode resource documentation, and added a security suggestion. 