### PR TITLE
Hotfix/xcode beta install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.2] - 2019-06-03
+
+### Fixed
+- Fixed an issue where Xcode versions containing whitespace were not properly quoted in command execution. Regression from version 2.10 release.
+
 ## [3.0.1] - 2019-03-15
 
 Thanks to @jkronborg for these two fixes!
@@ -7,6 +12,7 @@ Thanks to @jkronborg for these two fixes!
 ### Fixed
 - Fixed a guard in `keep_awake` for use on portables. 
 - Fixed incorrect attribute key in the Xcode resource documentation, and added a security suggestion. 
+
 ## [3.0.0] - 2019-02-28
 
 ### Added

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,21 +20,21 @@ platforms:
 - name: sierra-chef14
   driver:
     box: microsoft/macos-sierra
-    version: 10.12.6
+    box_version: 10.12.6
   provisioner:
     product_version: 14
 
 - name: high-sierra-chef14
   driver:
     box: microsoft/macos-high-sierra
-    version: 10.13.6-v2
+    box_version: 10.13.6-v2
   provisioner:
     product_version: 14
 
 - name: mojave-chef14
   driver:
     box: microsoft/macos-mojave
-    version: 10.14.3
+    box_version: 10.14.4
   provisioner:
     product_version: 14
 

--- a/libraries/system.rb
+++ b/libraries/system.rb
@@ -26,7 +26,7 @@ module MacOS
       end
 
       def vm?
-        @virtualization_systems.empty? || @virtualization_systems.values.include?('guest') ? true : false
+        @virtualization_systems.empty? || @virtualization_systems.value?('guest') ? true : false
       end
     end
 

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -43,7 +43,7 @@ module MacOS
 
     def current_path
       if installed_path.nil? && @version.match?(/beta/i)
-        "/Applications/Xcode-#{@apple_version}.Beta.app"
+        "/Applications/Xcode-#{@apple_version}.Beta.#{version.match(/beta\s(.)/)[1]}.app"
       elsif installed_path.nil? && !@version.match?(/beta/i)
         "/Applications/Xcode-#{@apple_version}.app"
       else

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -43,11 +43,12 @@ module MacOS
 
     def current_path
       if installed_path.nil? && @version.match?(/beta/i)
-        return '/Applications/Xcode-beta.app'
+        '/Applications/Xcode-beta.app'
+      elsif installed_path.nil? && !@version.match?(/beta/i)
+        "/Applications/Xcode-#{@apple_version}.app" 
       else
-        return "/Applications/Xcode-#{@apple_version}.app" 
+        installed_path[@semantic_version]
       end
-      installed_path[@semantic_version]
     end
 
     def installed?

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -45,7 +45,7 @@ module MacOS
       if installed_path.nil? && @version.match?(/beta/i)
         "/Applications/Xcode-#{@apple_version}.Beta.app"
       elsif installed_path.nil? && !@version.match?(/beta/i)
-        "/Applications/Xcode-#{@apple_version}.app" 
+        "/Applications/Xcode-#{@apple_version}.app"
       else
         installed_path[@semantic_version]
       end

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -43,7 +43,7 @@ module MacOS
 
     def current_path
       if installed_path.nil? && @version.match?(/beta/i)
-        '/Applications/Xcode-beta.app'
+        "/Applications/Xcode-#{@apple_version}.Beta.app"
       elsif installed_path.nil? && !@version.match?(/beta/i)
         "/Applications/Xcode-#{@apple_version}.app" 
       else

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -42,7 +42,11 @@ module MacOS
     end
 
     def current_path
-      return "/Applications/Xcode-#{@apple_version}.app" if installed_path.nil?
+      if installed_path.nil? && @version.match?(/beta/i)
+        return '/Applications/Xcode-beta.app'
+      else
+        return "/Applications/Xcode-#{@apple_version}.app" 
+      end
       installed_path[@semantic_version]
     end
 

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -42,7 +42,7 @@ module MacOS
       end
 
       def install_xcode(xcode)
-        xcversion "install #{xcode.version} #{download_url_option(xcode)}"
+        xcversion "install '#{xcode.version}' #{download_url_option(xcode)}".strip
       end
 
       def installed_xcodes

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.3'
+version '3.0.4'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.4'
+version '3.0.5'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.5'
+version '3.0.6'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.2'
+version '3.0.3'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.1'
+version '3.0.2'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -60,7 +60,7 @@ action :set do
     converge_by 'change format' do
       Chef::Application.fatal!(
         "Option encoding must be equal to one of: #{plutil_format_map.keys}!  You passed \"#{new_resource.encoding}\"."
-      ) unless plutil_format_map.keys.include? new_resource.encoding
+      ) unless plutil_format_map.key?(new_resource.encoding)
       execute ['/usr/bin/plutil', '-convert', plutil_format_map[new_resource.encoding], new_resource.path] do
         action :run
       end

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -4,6 +4,7 @@ include MacOS
 describe MacOS::Xcode do
   context 'when initialized without a download url and Xcode betas available' do
     before do
+      allow_any_instance_of(MacOS::Xcode).to receive(:installed_path).and_return nil
       allow(MacOS::XCVersion).to receive(:available_versions)
         .and_return(["4.3 for Lion\n",
                      "4.3.1 for Lion\n",
@@ -65,6 +66,10 @@ describe MacOS::Xcode do
     it 'returns the name of Xcode 9.4 beta when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
       expect(xcode.version).to eq '9.4.2 beta'
+    end
+    it 'returns the temporary beta path set by xcversion when initialized with the semantic version' do
+      xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
+      expect(xcode.current_path).to eq '/Applications/Xcode-beta.app'
     end
     it 'returns the name of Xcode 9.3 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.3', '/Applications/Xcode.app')

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -143,7 +143,7 @@ describe MacOS::Xcode::Simulator do
                     tvOS 11.1 Simulator (not installed)
                     watchOS 4.1 Simulator (not installed)
                     iOS 11.1 Simulator (not installed)
-                    XCVERSION_OUTPUT
+        XCVERSION_OUTPUT
                    )
     end
     it 'returns the latest semantic version of iOS 11' do
@@ -183,7 +183,7 @@ describe MacOS::Xcode::Simulator do
 
                     watchOS Simulator SDKs:
                             Simulator - watchOS 4.2       	-sdk watchsimulator4.2
-                    XCODEBUILD_OUTPUT
+          XCODEBUILD_OUTPUT
                      )
       end
       it 'determines that iOS 11 is included with this Xcode' do

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -69,7 +69,7 @@ describe MacOS::Xcode do
     end
     it 'returns the temporary beta path set by xcversion when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
-      expect(xcode.current_path).to eq '/Applications/Xcode-beta.app'
+      expect(xcode.current_path).to eq '/Applications/Xcode-9.4.2.Beta.app'
     end
     it 'returns the name of Xcode 9.3 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.3', '/Applications/Xcode.app')

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -65,11 +65,11 @@ describe MacOS::Xcode do
     end
     it 'returns the name of Xcode 9.4 beta when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
-      expect(xcode.version).to eq '9.4.2 beta'
+      expect(xcode.version).to eq '9.4.2 beta 2'
     end
     it 'returns the temporary beta path set by xcversion when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
-      expect(xcode.current_path).to eq '/Applications/Xcode-9.4.2.Beta.app'
+      expect(xcode.current_path).to eq '/Applications/Xcode-9.4.2.Beta.2.app'
     end
     it 'returns the name of Xcode 9.3 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.3', '/Applications/Xcode.app')

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -55,7 +55,7 @@ describe MacOS::Xcode do
                      "9.3\n",
                      "9.4\n",
                      "9.4.1\n",
-                     "9.4.2 beta\n",
+                     "9.4.2 beta 2\n",
                      "10 GM seed\n"]
                    )
     end

--- a/spec/unit/libraries/xcversion_spec.rb
+++ b/spec/unit/libraries/xcversion_spec.rb
@@ -12,10 +12,17 @@ describe MacOS::XCVersion do
   context 'when given an Xcode object without a download url' do
     before do
       allow(MacOS::XCVersion).to receive(:available_versions).and_return(["10 GM seed\n"])
+      allow(MacOS::XCVersion).to receive(:xcversion_path).and_return('/foo/bar/bin/xcversion')
     end
-    it 'returns the appropriate --url syntax' do
+
+    it 'passes an empty string for the url parameter' do
       xcode = MacOS::Xcode.new('10.0', '/Applications/Xcode.app', '')
       expect(XCVersion.download_url_option(xcode)).to eq ''
+    end
+
+    it 'executes the correct xcversion command with quotes around the version' do
+      xcode = MacOS::Xcode.new('10.0', '/Applications/Xcode.app', '')
+      expect(XCVersion.install_xcode(xcode)).to eq "/foo/bar/bin/xcversion install '10 GM seed'"
     end
   end
 end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -123,7 +123,7 @@ describe 'xcode' do
     it { is_expected.to run_execute('install Xcode 9.4.2 beta') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-beta.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-beta.app to /Applications/Xcode.app').with(command: ['mv', '/Applications/Xcode-beta.app', '/Applications/Xcode.app']) }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -123,7 +123,7 @@ describe 'xcode' do
     it { is_expected.to run_execute('install Xcode 9.4.2 beta') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-beta.app to /Applications/Xcode.app').with(command: ['mv', '/Applications/Xcode-beta.app', '/Applications/Xcode.app']) }
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.2.Beta.app to /Applications/Xcode.app').with(command: ['mv', '/Applications/Xcode-9.4.2.Beta.app', '/Applications/Xcode.app']) }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -120,10 +120,10 @@ describe 'xcode' do
       end
     end
 
-    it { is_expected.to run_execute('install Xcode 9.4.2 beta') }
+    it { is_expected.to run_execute('install Xcode 9.4.2 beta 2') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.2.Beta.app to /Applications/Xcode.app').with(command: ['mv', '/Applications/Xcode-9.4.2.Beta.app', '/Applications/Xcode.app']) }
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.2.Beta.2.app to /Applications/Xcode.app').with(command: ['mv', '/Applications/Xcode-9.4.2.Beta.2.app', '/Applications/Xcode.app']) }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -80,7 +80,7 @@ describe 'xcode' do
                    "9.3.1\n",
                    "9.4\n",
                    "9.4.1\n",
-                   "9.4.2 beta\n"]
+                   "9.4.2 beta 2\n"]
                  )
     allow(File).to receive(:exist?).and_call_original
     allow(FileUtils).to receive(:touch).and_return(true)

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -79,7 +79,8 @@ describe 'xcode' do
                    "9.3\n",
                    "9.3.1\n",
                    "9.4\n",
-                   "9.4.1\n"]
+                   "9.4.1\n",
+                   "9.4.2 beta\n"]
                  )
     allow(File).to receive(:exist?).and_call_original
     allow(FileUtils).to receive(:touch).and_return(true)
@@ -106,7 +107,7 @@ describe 'xcode' do
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
-  context 'with no Xcodes installed' do
+  context 'with no Xcodes installed, and a beta Xcode requested' do
     before(:each) do
       allow(MacOS::XCVersion).to receive(:installed_xcodes)
         .and_return([])
@@ -114,13 +115,15 @@ describe 'xcode' do
     end
 
     recipe do
-      xcode '10.0'
+      xcode 'betamax!' do
+        version '9.4.2'
+      end
     end
 
-    it { is_expected.to run_execute('install Xcode 10') }
+    it { is_expected.to run_execute('install Xcode 9.4.2 beta') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-10.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-beta.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 

--- a/test/cookbooks/macos_test/recipes/certificate.rb
+++ b/test/cookbooks/macos_test/recipes/certificate.rb
@@ -1,4 +1,3 @@
-
 cookbook_file '/Users/vagrant/Test.p12' do
   action :create
   source 'Test.p12'


### PR DESCRIPTION
# Install Xcode versions with  whitespace

## This PR
- Fixes an issue where Xcode versions containing whitespace were not properly quoted in command execution.
- Regression from version 2.10 release.
