### PR TITLE
change version property to box_version

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,21 +20,21 @@ platforms:
 - name: sierra-chef14
   driver:
     box: microsoft/macos-sierra
-    version: 10.12.6
+    box_version: 10.12.6
   provisioner:
     product_version: 14
 
 - name: high-sierra-chef14
   driver:
     box: microsoft/macos-high-sierra
-    version: 10.13.6-v2
+    box_version: 10.13.6-v2
   provisioner:
     product_version: 14
 
 - name: mojave-chef14
   driver:
     box: microsoft/macos-mojave
-    version: 10.14.3
+    box_version: 10.14.4
   provisioner:
     product_version: 14
 


### PR DESCRIPTION
### This PR
- Changes the `version` property for vagrant boxes in kitchen to `box_version`

### Why
The `version` property is the incorrect naming for specifying a box version to download from the vagrant storage. We went 3+ years without it being a problem until now `whoops`. 