### PR TITLE
Fix 11 GM Seed installation

### DIFF
--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -42,11 +42,8 @@ module MacOS
     end
 
     def current_path
-      if installed_path.nil? && @version.match?(/beta/i)
-        beta_revision = @version.match(/beta\s(.)/i)[1]
-        "/Applications/Xcode-#{@apple_version}.Beta.#{beta_revision}.app"
-      elsif installed_path.nil? && !@version.match?(/beta/i)
-        "/Applications/Xcode-#{@apple_version}.app"
+      if installed_path.nil?
+        "/Applications/Xcode-#{@version.tr(' ', '.')}.app"
       else
         installed_path[@semantic_version]
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '3.0.8'
+version '3.0.9'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -69,7 +69,7 @@ describe MacOS::Xcode do
     end
     it 'returns the temporary beta path set by xcversion when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
-      expect(xcode.current_path).to eq '/Applications/Xcode-9.4.2.Beta.2.app'
+      expect(xcode.current_path).to eq '/Applications/Xcode-9.4.2.beta.2.app'
     end
     it 'returns the name of Xcode 9.3 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.3', '/Applications/Xcode.app')

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -123,7 +123,7 @@ describe 'xcode' do
     it { is_expected.to run_execute('install Xcode 9.4.2 beta 2') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-9.4.2.Beta.2.app to /Applications/Xcode.app').with(command: ['mv', '/Applications/Xcode-9.4.2.Beta.2.app', '/Applications/Xcode.app']) }
+    it { is_expected.to run_execute('move /Applications/Xcode-9.4.2.beta.2.app to /Applications/Xcode.app').with(command: ['mv', '/Applications/Xcode-9.4.2.beta.2.app', '/Applications/Xcode.app']) }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 
@@ -144,7 +144,7 @@ describe 'xcode' do
     it { is_expected.to run_execute('install Xcode 0.0') }
     it { is_expected.to delete_link('/Applications/Xcode.app') }
 
-    it { is_expected.to run_execute('move /Applications/Xcode-0.app to /Applications/Xcode.app') }
+    it { is_expected.to run_execute('move /Applications/Xcode-0.0.app to /Applications/Xcode.app') }
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 


### PR DESCRIPTION
## [3.0.9] - 2019-09-11

### Fixed
Fixed an issue where the Xcode resource cannot find the Xcode 11 GM bundle path to move it to the declared `path` in the resource. 

It removes a logic tree in favor of matching the behavior of the xcode-install gem: https://github.com/xcpretty/xcode-install/blob/74b89805462d6795d964935239f78e6d2790a52d/lib/xcode/install.rb#L282, which is to replace spaces in the version listed by Apple with a period. 
