### PR TITLE
Add path helper classes

### DIFF
--- a/libraries/paths.rb
+++ b/libraries/paths.rb
@@ -1,0 +1,45 @@
+module LabCore
+  class UserPath
+    class << self
+      def home(user)
+        SysPath.directory('Users', user)
+      end
+
+      def directory(user, *dirs)
+        ::File.join(home(user), dirs)
+      end
+
+      def library(user)
+        ::File.join(home(user), 'Library')
+      end
+
+      def preferences(user)
+        ::File.join(home(user), 'Library/Preferences')
+      end
+
+      def plist(user, plist)
+        ::File.join(preferences(user), plist)
+      end
+    end
+  end
+
+  class SysPath
+    class << self
+      def directory(*dirs)
+        ::File.join(root, dirs)
+      end
+
+      def root
+        '/'
+      end
+
+      def library
+        ::File.join(root, 'Library')
+      end
+
+      def preferences
+        ::File.join(library, 'Preferences')
+      end
+    end
+  end
+end

--- a/libraries/paths.rb
+++ b/libraries/paths.rb
@@ -1,8 +1,8 @@
-module LabCore
+module MacOS
   class UserPath
     class << self
       def home(user)
-        SysPath.directory('Users', user)
+        SystemPath.directory('Users', user)
       end
 
       def directory(user, *dirs)
@@ -23,7 +23,7 @@ module LabCore
     end
   end
 
-  class SysPath
+  class SystemPath
     class << self
       def directory(*dirs)
         ::File.join(root, dirs)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require_relative '../libraries/command_line_tools'
 require_relative '../libraries/security_cmd'
 require_relative '../libraries/software_updates'
 require_relative '../libraries/remote_management'
+require_relative '../libraries/paths'
 
 RSpec.configure do |config|
   config.platform = 'mac_os_x'

--- a/spec/unit/libraries/paths_spec.rb
+++ b/spec/unit/libraries/paths_spec.rb
@@ -1,48 +1,48 @@
 require 'spec_helper'
-include LabCore
+include MacOS
 
 user_name = 'test'
 
-describe LabCore::UserPath, 'UserPath library helper functions' do
+describe MacOS::UserPath, 'UserPath library helper functions' do
   context 'using UserPath library routines to create paths' do
     it 'home creates the correct path to user home' do
       expect(UserPath.home(user_name)).to eq "/Users/#{user_name}"
     end
 
-    it "directory creates the correct paths directories in #{user_name}." do
+    it "directory creates the correct paths directories in #{user_name}" do
       expect(UserPath.directory(user_name, 'how', 'now', 'brown', 'cow')).to eq "/Users/#{user_name}/how/now/brown/cow"
     end
 
-    it 'library creates the correct path to user Library directory.' do
+    it 'library creates the correct path to user Library directory' do
       expect(UserPath.library(user_name)).to eq "/Users/#{user_name}/Library"
     end
 
-    it 'preferences creates the correct path to user preference directory.' do
+    it 'preferences creates the correct path to user preference directory' do
       expect(UserPath.preferences(user_name)).to eq "/Users/#{user_name}/Library/Preferences"
     end
 
-    it 'plist creates the correct path to the specified user plist.' do
+    it 'plist creates the correct path to the specified user plist' do
       expect(UserPath.plist(user_name, 'com.apple.screensaver.plist')).to eq "/Users/#{user_name}/Library/Preferences/com.apple.screensaver.plist"
     end
   end
 end
 
-describe LabCore::SysPath, 'SysPath library helper functions' do
-  context 'using SysPath library routines to create paths' do
+describe MacOS::SystemPath, 'SystemPath library helper functions' do
+  context 'using SystemPath library routines to create paths' do
     it 'directory creates the correct directory path' do
-      expect(SysPath.directory('how', 'now', 'brown', 'cow')).to eq '/how/now/brown/cow'
+      expect(SystemPath.directory('how', 'now', 'brown', 'cow')).to eq '/how/now/brown/cow'
     end
 
     it 'root creates the correct system path' do
-      expect(SysPath.root).to eq '/'
+      expect(SystemPath.root).to eq '/'
     end
 
     it 'library creates the correct system library path' do
-      expect(SysPath.library).to eq '/Library'
+      expect(SystemPath.library).to eq '/Library'
     end
 
     it 'preferences creates the correct system preferences path' do
-      expect(SysPath.preferences).to eq '/Library/Preferences'
+      expect(SystemPath.preferences).to eq '/Library/Preferences'
     end
   end
 end

--- a/spec/unit/libraries/paths_spec.rb
+++ b/spec/unit/libraries/paths_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+include LabCore
+
+user_name = 'test'
+
+describe LabCore::UserPath, 'UserPath library helper functions' do
+  context 'using UserPath library routines to create paths' do
+    it 'home creates the correct path to user home' do
+      expect(UserPath.home(user_name)).to eq "/Users/#{user_name}"
+    end
+
+    it "directory creates the correct paths directories in #{user_name}." do
+      expect(UserPath.directory(user_name, 'how', 'now', 'brown', 'cow')).to eq "/Users/#{user_name}/how/now/brown/cow"
+    end
+
+    it 'library creates the correct path to user Library directory.' do
+      expect(UserPath.library(user_name)).to eq "/Users/#{user_name}/Library"
+    end
+
+    it 'preferences creates the correct path to user preference directory.' do
+      expect(UserPath.preferences(user_name)).to eq "/Users/#{user_name}/Library/Preferences"
+    end
+
+    it 'plist creates the correct path to the specified user plist.' do
+      expect(UserPath.plist(user_name, 'com.apple.screensaver.plist')).to eq "/Users/#{user_name}/Library/Preferences/com.apple.screensaver.plist"
+    end
+  end
+end
+
+describe LabCore::SysPath, 'SysPath library helper functions' do
+  context 'using SysPath library routines to create paths' do
+    it 'directory creates the correct directory path' do
+      expect(SysPath.directory('how', 'now', 'brown', 'cow')).to eq '/how/now/brown/cow'
+    end
+
+    it 'root creates the correct system path' do
+      expect(SysPath.root).to eq '/'
+    end
+
+    it 'library creates the correct system library path' do
+      expect(SysPath.library).to eq '/Library'
+    end
+
+    it 'preferences creates the correct system preferences path' do
+      expect(SysPath.preferences).to eq '/Library/Preferences'
+    end
+  end
+end


### PR DESCRIPTION
## This PR
Adds a library of helper methods for reducing duplication in specifying macOS user and system paths. Thanks @mjmerin!