### PR TITLE
Remove chef-sugar dependency

### DIFF
--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -1,5 +1,4 @@
 include Chef::Mixin::ShellOut
-include Chef::Sugar::Platform
 include MacOS
 
 module MacOS
@@ -23,10 +22,16 @@ module MacOS
                  end
     end
 
-    def compatible_with_platform?(node)
-      return true if mac_os_x_after_or_at_high_sierra?(node)
-      vintage_xcode = Gem::Dependency.new('Xcode', '< 9.3')
-      vintage_xcode.match?('Xcode', @semantic_version)
+    def compatible_with_platform?(macos_version)
+      Gem::Dependency.new('macOS', minimum_required_os).match?('macOS', macos_version)
+    end
+
+    def minimum_required_os
+      return '>= 10.12.6' if Gem::Dependency.new('Xcode', '<= 9.2').match?('Xcode', @semantic_version)
+      return '>= 10.13.2' if Gem::Dependency.new('Xcode', '>= 9.3', '<= 9.4.1').match?('Xcode', @semantic_version)
+      return '>= 10.13.6' if Gem::Dependency.new('Xcode', '>= 10.0', '<= 10.1').match?('Xcode', @semantic_version)
+      return '>= 10.14.3' if Gem::Dependency.new('Xcode', '>= 10.2', '<= 10.3').match?('Xcode', @semantic_version)
+      return '>= 10.14.4' if Gem::Dependency.new('Xcode', '>= 11.0').match?('Xcode', @semantic_version)
     end
 
     def xcode_index(version)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -27,7 +27,7 @@ module MacOS
     end
 
     def minimum_required_os
-      return '>= 10.12.6' if Gem::Dependency.new('Xcode', '<= 9.2').match?('Xcode', @semantic_version)
+      return '>= 0' if Gem::Dependency.new('Xcode', '<= 9.2').match?('Xcode', @semantic_version)
       return '>= 10.13.2' if Gem::Dependency.new('Xcode', '>= 9.3', '<= 9.4.1').match?('Xcode', @semantic_version)
       return '>= 10.13.6' if Gem::Dependency.new('Xcode', '>= 10.0', '<= 10.1').match?('Xcode', @semantic_version)
       return '>= 10.14.3' if Gem::Dependency.new('Xcode', '>= 10.2', '<= 10.3').match?('Xcode', @semantic_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,3 @@ source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'
 
 supports 'mac_os_x'
-
-depends 'chef-sugar', '~> 5.0'

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -46,6 +46,7 @@ action :install_xcode do
     command XCVersion.install_xcode(xcode)
     environment developer.credentials
     not_if { xcode.installed? }
+    live_stream true
     timeout 7200
   end
 

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -36,7 +36,7 @@ action :install_xcode do
     new_resource.download_url
   )
 
-  unless xcode.compatible_with_platform?(node)
+  unless xcode.compatible_with_platform?(node['platform_version'])
     ruby_block 'exception' do
       raise("Xcode #{xcode.version} not supported before macOS High Sierra")
     end

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -38,7 +38,7 @@ action :install_xcode do
 
   unless xcode.compatible_with_platform?(node['platform_version'])
     ruby_block 'exception' do
-      raise("Xcode #{xcode.version} not supported before macOS High Sierra")
+      raise("Xcode #{xcode.version} not supported on #{node['platform_version']}")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,5 +16,5 @@ require_relative '../libraries/remote_management'
 
 RSpec.configure do |config|
   config.platform = 'mac_os_x'
-  config.version = '10.13'
+  config.version = '10.14'
 end

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -56,7 +56,10 @@ describe MacOS::Xcode do
                      "9.4\n",
                      "9.4.1\n",
                      "9.4.2 beta 2\n",
-                     "10 GM seed\n"]
+                     "10 GM seed\n",
+                     "10.1\n",
+                     "10.3\n",
+                     "11.0\n"]
                    )
     end
     it 'returns the name of Xcode 10 GM when initialized with the semantic version' do
@@ -82,6 +85,46 @@ describe MacOS::Xcode do
     it 'returns the name of Xcode 8.3.3 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('8.3.3', '/Applications/Xcode.app')
       expect(xcode.version).to eq '8.3.3'
+    end
+    it 'correctly determines platform compatibility for Xcode 11' do
+      xcode = MacOS::Xcode.new('11.0', '/Applications/Xcode.app')
+      expect(xcode.compatible_with_platform?('10.14.4')).to be true
+      expect(xcode.compatible_with_platform?('10.14.3')).to be false
+      expect(xcode.compatible_with_platform?('10.13.6')).to be false
+      expect(xcode.compatible_with_platform?('10.13.2')).to be false
+      expect(xcode.compatible_with_platform?('10.12.6')).to be false
+    end
+    it 'correctly determines platform compatibility for Xcode 10.3' do
+      xcode = MacOS::Xcode.new('10.3', '/Applications/Xcode.app')
+      expect(xcode.compatible_with_platform?('10.14.4')).to be true
+      expect(xcode.compatible_with_platform?('10.14.3')).to be true
+      expect(xcode.compatible_with_platform?('10.13.6')).to be false
+      expect(xcode.compatible_with_platform?('10.13.2')).to be false
+      expect(xcode.compatible_with_platform?('10.12.6')).to be false
+    end
+    it 'correctly determines platform compatibility for Xcode 10.1' do
+      xcode = MacOS::Xcode.new('10.1', '/Applications/Xcode.app')
+      expect(xcode.compatible_with_platform?('10.14.4')).to be true
+      expect(xcode.compatible_with_platform?('10.14.3')).to be true
+      expect(xcode.compatible_with_platform?('10.13.6')).to be true
+      expect(xcode.compatible_with_platform?('10.13.2')).to be false
+      expect(xcode.compatible_with_platform?('10.12.6')).to be false
+    end
+    it 'correctly determines platform compatibility for Xcode 9.4.1' do
+      xcode = MacOS::Xcode.new('9.4.1', '/Applications/Xcode.app')
+      expect(xcode.compatible_with_platform?('10.14.4')).to be true
+      expect(xcode.compatible_with_platform?('10.14.3')).to be true
+      expect(xcode.compatible_with_platform?('10.13.6')).to be true
+      expect(xcode.compatible_with_platform?('10.13.2')).to be true
+      expect(xcode.compatible_with_platform?('10.12.6')).to be false
+    end
+    it 'correctly determines platform compatibility for Xcode 9.2' do
+      xcode = MacOS::Xcode.new('9.2', '/Applications/Xcode.app')
+      expect(xcode.compatible_with_platform?('10.14.4')).to be true
+      expect(xcode.compatible_with_platform?('10.14.3')).to be true
+      expect(xcode.compatible_with_platform?('10.13.6')).to be true
+      expect(xcode.compatible_with_platform?('10.13.2')).to be true
+      expect(xcode.compatible_with_platform?('10.12.6')).to be true
     end
   end
 end

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -93,6 +93,7 @@ describe MacOS::Xcode do
       expect(xcode.compatible_with_platform?('10.13.6')).to be false
       expect(xcode.compatible_with_platform?('10.13.2')).to be false
       expect(xcode.compatible_with_platform?('10.12.6')).to be false
+      expect(xcode.compatible_with_platform?('0')).to be false
     end
     it 'correctly determines platform compatibility for Xcode 10.3' do
       xcode = MacOS::Xcode.new('10.3', '/Applications/Xcode.app')
@@ -101,6 +102,7 @@ describe MacOS::Xcode do
       expect(xcode.compatible_with_platform?('10.13.6')).to be false
       expect(xcode.compatible_with_platform?('10.13.2')).to be false
       expect(xcode.compatible_with_platform?('10.12.6')).to be false
+      expect(xcode.compatible_with_platform?('0')).to be false
     end
     it 'correctly determines platform compatibility for Xcode 10.1' do
       xcode = MacOS::Xcode.new('10.1', '/Applications/Xcode.app')
@@ -109,6 +111,7 @@ describe MacOS::Xcode do
       expect(xcode.compatible_with_platform?('10.13.6')).to be true
       expect(xcode.compatible_with_platform?('10.13.2')).to be false
       expect(xcode.compatible_with_platform?('10.12.6')).to be false
+      expect(xcode.compatible_with_platform?('0')).to be false
     end
     it 'correctly determines platform compatibility for Xcode 9.4.1' do
       xcode = MacOS::Xcode.new('9.4.1', '/Applications/Xcode.app')
@@ -117,6 +120,7 @@ describe MacOS::Xcode do
       expect(xcode.compatible_with_platform?('10.13.6')).to be true
       expect(xcode.compatible_with_platform?('10.13.2')).to be true
       expect(xcode.compatible_with_platform?('10.12.6')).to be false
+      expect(xcode.compatible_with_platform?('0')).to be false
     end
     it 'correctly determines platform compatibility for Xcode 9.2' do
       xcode = MacOS::Xcode.new('9.2', '/Applications/Xcode.app')
@@ -125,6 +129,7 @@ describe MacOS::Xcode do
       expect(xcode.compatible_with_platform?('10.13.6')).to be true
       expect(xcode.compatible_with_platform?('10.13.2')).to be true
       expect(xcode.compatible_with_platform?('10.12.6')).to be true
+      expect(xcode.compatible_with_platform?('0')).to be true # not enforcing compatibility on vintage Xcodes
     end
   end
 end

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -122,14 +122,23 @@ describe MacOS::Xcode do
       expect(xcode.compatible_with_platform?('10.12.6')).to be false
       expect(xcode.compatible_with_platform?('0')).to be false
     end
-    it 'correctly determines platform compatibility for Xcode 9.2' do
+    it 'correctly determines platform compatibility for a vintage Xcode' do
       xcode = MacOS::Xcode.new('9.2', '/Applications/Xcode.app')
       expect(xcode.compatible_with_platform?('10.14.4')).to be true
       expect(xcode.compatible_with_platform?('10.14.3')).to be true
       expect(xcode.compatible_with_platform?('10.13.6')).to be true
       expect(xcode.compatible_with_platform?('10.13.2')).to be true
       expect(xcode.compatible_with_platform?('10.12.6')).to be true
-      expect(xcode.compatible_with_platform?('0')).to be true # not enforcing compatibility on vintage Xcodes
+      expect(xcode.compatible_with_platform?('0')).to be true # not enforcing compatibilty for vintage or obsolete Xcodes
+    end
+    it 'correctly determines platform compatibility for an obsolete Xcode' do
+      xcode = MacOS::Xcode.new('8.2.1', '/Applications/Xcode.app')
+      expect(xcode.compatible_with_platform?('10.14.4')).to be true
+      expect(xcode.compatible_with_platform?('10.14.3')).to be true
+      expect(xcode.compatible_with_platform?('10.13.6')).to be true
+      expect(xcode.compatible_with_platform?('10.13.2')).to be true
+      expect(xcode.compatible_with_platform?('10.12.6')).to be true
+      expect(xcode.compatible_with_platform?('0')).to be true # not enforcing compatibilty for vintage or obsolete Xcodes
     end
   end
 end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -143,7 +143,7 @@ describe 'xcode' do
     end
 
     it 'raises an error' do
-      expect { subject }.to raise_error(RuntimeError, /Xcode 10\.1 beta 2 not supported before macOS High Sierra/)
+      expect { subject }.to raise_error(RuntimeError, /Xcode 10\.1 beta 2 not supported on 10.12/)
     end
   end
 

--- a/test/cookbooks/macos_test/recipes/xcode_from_apple.rb
+++ b/test/cookbooks/macos_test/recipes/xcode_from_apple.rb
@@ -1,8 +1,7 @@
-if mac_os_x_after_high_sierra?
+if node['platform_version'] >= '10.14.4'
   xcode '11.0'
-
-elsif mac_os_x_high_sierra?
-  xcode '10.1' do
-    ios_simulators %w(12 11)
+else
+  xcode '9.4.1' do
+    ios_simulators %w(11 10)
   end
 end

--- a/test/cookbooks/macos_test/recipes/xcode_from_url.rb
+++ b/test/cookbooks/macos_test/recipes/xcode_from_url.rb
@@ -1,12 +1,11 @@
-if mac_os_x_after_high_sierra?
+if node['platform_version'] >= '10.14.4'
   xcode 'installs 11.0' do
     download_url node['xcode']['download_url']
     version '11.0'
   end
-
-elsif mac_os_x_high_sierra?
-  xcode 'installs 10.1' do
+else
+  xcode 'installs 9.4.1' do
     download_url node['xcode']['download_url']
-    version '10.1'
+    version '9.4.1'
   end
 end


### PR DESCRIPTION
## This PR
- Removes the chef-sugar cookbook dependency and replaces the calls the gem dependency. 
- The Xcode platform compatibility logic has also been extended to be more precise regarding minor macOS platforms. We make no attempt to warn the user of incompatibility if you're installing an Xcode whose platform support varies prior to our overall scope (Sierra and earlier). 

## Justification  
As `macos` is intended to be a dependency itself, we felt it should have no _cookbook_ dependencies of it's own. 