### PR TITLE
Feature/improve clt speed

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -102,6 +102,7 @@ suites:
   verifier:
     controls:
     - command-line-tool-sentinel
+    - xcrun
 
 - name: certificate
   run_list:

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -12,7 +12,7 @@ module MacOS
         FileUtils.touch install_sentinel
         FileUtils.chown 'root', 'wheel', install_sentinel
         @version = if available.empty?
-                     'No Command Lines Tools available from Software Update Catalog!'
+                     'No Command Line Tools available from Software Update Catalog!'
                    elsif platform_specific.empty?
                      "No Command Line Tools specific to #{macos_version} available from Software Update Catalog!"
                    else

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -5,27 +5,41 @@ module MacOS
     attr_reader :version
 
     def initialize
-      softwareupdate_history = shell_out(['softwareupdate', '--history']).stdout
-      history_entry = softwareupdate_history.lines.select { |line| line.include?('Command Line Tools') }
       if history_entry.empty?
         install_sentinel = '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
         FileUtils.touch install_sentinel
         FileUtils.chown 'root', 'wheel', install_sentinel
         @version = if available.empty?
-                     'No Command Line Tools available from Software Update Catalog!'
-                   elsif platform_specific.empty?
-                     "No Command Line Tools specific to #{macos_version} available from Software Update Catalog!"
+                     Chef::Log.warn 'No Command Line Tools available from Software Update Catalog!'
                    else
-                     latest.tr('*', '').strip
+                     latest.tr('*', '').gsub('Label: ', '').strip
                    end
       else
-        @version = history_entry.first.split('  ').first
+        @version = history_version
       end
     end
 
     def latest
-      versions = platform_specific.map { |product| Gem::Version.new xcode_version(product) }
-      platform_specific.detect { |product| product.include? versions.max.version }
+      if platform_specific.empty?
+        Chef::Log.info "No Command Line Tools specific to #{macos_version} available from Software Update Catalog, selecting by maximum Xcode version."
+        versions = available.map { |product| Gem::Version.new xcode_version(product) }
+        available.detect { |product| product.include? versions.max.version }
+      else
+        versions = platform_specific.map { |product| Gem::Version.new xcode_version(product) }
+        platform_specific.detect { |product| product.include? versions.max.version }
+      end
+    end
+
+    def softwareupdate_history
+      shell_out(['softwareupdate', '--history']).stdout.lines
+    end
+
+    def history_entry
+      softwareupdate_history.select { |line| line.include?('Command Line Tools') }
+    end
+
+    def history_version
+      history_entry.first.split('  ').reject(&:empty?).map(&:strip).first(2).join '-'
     end
 
     def platform_specific
@@ -33,7 +47,7 @@ module MacOS
     end
 
     def available
-      softwareupdate_list.select { |product_name| product_name.include?('Command Line Tools') }
+      softwareupdate_list.select { |product_name| product_name.match /\*.{1,8}Command Line Tools/ }
     end
 
     def xcode_version(product)

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -7,8 +7,7 @@ module MacOS
     def initialize
       softwareupdate_history = shell_out(['softwareupdate', '--history']).stdout
       history_entry = softwareupdate_history.lines.select { |line| line.include?('Command Line Tools') }
-
-      if history_entry.nil?
+      if history_entry.empty?
         install_sentinel = '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
         FileUtils.touch install_sentinel
         FileUtils.chown 'root', 'wheel', install_sentinel

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -33,7 +33,7 @@ module MacOS
     end
 
     def available
-      softwareupdate_list.select { |product_name| product_name.include?('* Command Line Tools') }
+      softwareupdate_list.select { |product_name| product_name.include?('Command Line Tools') }
     end
 
     def xcode_version(product)

--- a/spec/unit/libraries/command_line_tools_spec.rb
+++ b/spec/unit/libraries/command_line_tools_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 include MacOS
 
 describe MacOS::CommandLineTools do
-  context 'when provided an available list of software update products in Mojave' do
+  context 'when provided an available list of software update products in Mojave, and no previous installation' do
     before do
       allow(FileUtils).to receive(:touch).and_return(true)
       allow(FileUtils).to receive(:chown).and_return(true)
@@ -21,8 +21,12 @@ describe MacOS::CommandLineTools do
                      "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
                      "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
                      "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
-                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
-                   )
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_history)
+        .and_return(["Display Name                                       Version    Date                  \n",
+                     "------------                                       -------    ----                  \n",
+                     "XProtectPlistConfigData                            2106       10/01/2019, 13:25:12  \n",
+                     "Gatekeeper Configuration Data                      181        09/30/2019, 13:36:29  \n"])
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
@@ -30,7 +34,7 @@ describe MacOS::CommandLineTools do
     end
   end
 
-  context 'when provided an incomplete list of software update products in Mojave' do
+  context 'when provided an incomplete list of software update products in Mojave, and no previous installation' do
     before do
       allow(FileUtils).to receive(:touch).and_return(true)
       allow(FileUtils).to receive(:chown).and_return(true)
@@ -47,16 +51,20 @@ describe MacOS::CommandLineTools do
                      "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
                      "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
                      "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
-                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
-                   )
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_history)
+        .and_return(["Display Name                                       Version    Date                  \n",
+                     "------------                                       -------    ----                  \n",
+                     "XProtectPlistConfigData                            2106       10/01/2019, 13:25:12  \n",
+                     "Gatekeeper Configuration Data                      181        09/30/2019, 13:36:29  \n"])
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
-      expect(clt.version).to eq 'No Command Line Tools specific to 10.14 available from Software Update Catalog!'
+      expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0'
     end
   end
 
-  context 'when provided an available list of software update products in High Sierra' do
+  context 'when provided an available list of software update products in High Sierra, and no previous installation' do
     before do
       allow(FileUtils).to receive(:touch).and_return(true)
       allow(FileUtils).to receive(:chown).and_return(true)
@@ -73,12 +81,67 @@ describe MacOS::CommandLineTools do
                      "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
                      "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
                      "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
-                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
-                   )
+                     "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_history)
+        .and_return(["Display Name                                       Version    Date                  \n",
+                     "------------                                       -------    ----                  \n",
+                     "XProtectPlistConfigData                            2106       10/01/2019, 13:25:12  \n",
+                     "Gatekeeper Configuration Data                      181        09/30/2019, 13:36:29  \n"])
     end
     it 'returns the latest recommended Command Line Tools product' do
       clt = MacOS::CommandLineTools.new
       expect(clt.version).to eq 'Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0'
+    end
+  end
+
+  context 'when provided an available list of software update products in Catalina, and no previous installation' do
+    before do
+      allow(FileUtils).to receive(:touch).and_return(true)
+      allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+        .and_return('10.15')
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "\n", "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "* Label: Command Line Tools for Xcode-11.0\n",
+                     "\tTitle: Command Line Tools for Xcode, Version: 11.0, Size: 224868K, Recommended: YES, \n"])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_history)
+        .and_return(["Display Name                                       Version    Date                  \n",
+                     "------------                                       -------    ----                  \n",
+                     "XProtectPlistConfigData                            2106       10/01/2019, 13:25:12  \n",
+                     "Gatekeeper Configuration Data                      181        09/30/2019, 13:36:29  \n"])
+    end
+    it 'returns the latest recommended Command Line Tools product' do
+      clt = MacOS::CommandLineTools.new
+      expect(clt.version).to eq 'Command Line Tools for Xcode-11.0'
+    end
+  end
+
+  context 'when provided an available list of software update products in Catalina, and version 11 already installed' do
+    before do
+      allow(FileUtils).to receive(:touch).and_return(true)
+      allow(FileUtils).to receive(:chown).and_return(true)
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+        .and_return('10.15')
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "\n", "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "* Label: Command Line Tools for Xcode-22.0\n",
+                     "\tTitle: Command Line Tools for Xcode, Version: 22.0, Size: 224868K, Recommended: YES, \n"])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_history)
+        .and_return(["Display Name                                       Version    Date                  \n",
+                     "------------                                       -------    ----                  \n",
+                     "XProtectPlistConfigData                            2106       10/01/2019, 13:25:12  \n",
+                     "Command Line Tools for Xcode                       11.0       10/01/2019, 13:25:10  \n",
+                     "MRTConfigData                                      1.49       09/30/2019, 13:36:29  \n",
+                     "Gatekeeper Configuration Data                      181        09/30/2019, 13:36:29  \n"])
+    end
+    it 'returns the latest recommended Command Line Tools product' do
+      clt = MacOS::CommandLineTools.new
+      expect(clt.version).to eq 'Command Line Tools for Xcode-11.0'
+      expect(clt.version).to_not eq 'Command Line Tools for Xcode-22.0'
     end
   end
 end

--- a/spec/unit/resources/command_line_tools_spec.rb
+++ b/spec/unit/resources/command_line_tools_spec.rb
@@ -20,8 +20,12 @@ describe 'command_line_tools' do
                    "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3\n",
                    "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.3), 187312K [recommended]\n",
                    "   * Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4\n",
-                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"]
-                 )
+                   "\tCommand Line Tools (macOS High Sierra version 10.13) for Xcode (9.4), 187380K [recommended]\n"])
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_history)
+      .and_return(["Display Name                                       Version    Date                  \n",
+                   "------------                                       -------    ----                  \n",
+                   "XProtectPlistConfigData                            2106       10/01/2019, 13:25:12  \n",
+                   "Gatekeeper Configuration Data                      181        09/30/2019, 13:36:29  \n"])
     allow(File).to receive(:exist?).and_call_original
     allow(FileUtils).to receive(:touch).and_return(true)
     allow(FileUtils).to receive(:chown).and_return(true)
@@ -49,5 +53,53 @@ describe 'command_line_tools' do
     end
 
     it { is_expected.to_not run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
+  end
+end
+
+describe 'command_line_tools' do
+  step_into :command_line_tools
+  platform 'mac_os_x'
+
+  before(:each) do
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:macos_version)
+      .and_return('10.15')
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+      .and_return(["Software Update Tool\n",
+                   "\n", "Finding available software\n",
+                   "Software Update found the following new or updated software:\n",
+                   "* Label: Command Line Tools for Xcode-11.0\n",
+                   "\tTitle: Command Line Tools for Xcode, Version: 11.0, Size: 224868K, Recommended: YES, \n"])
+    allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_history)
+      .and_return(["Display Name                                       Version    Date                  \n",
+                   "------------                                       -------    ----                  \n",
+                   "XProtectPlistConfigData                            2106       10/01/2019, 13:25:12  \n",
+                   "Gatekeeper Configuration Data                      181        09/30/2019, 13:36:29  \n"])
+    allow(File).to receive(:exist?).and_call_original
+    allow(FileUtils).to receive(:touch).and_return(true)
+    allow(FileUtils).to receive(:chown).and_return(true)
+  end
+
+  context 'with no CLT installed' do
+    before(:each) do
+      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib').and_return(false)
+    end
+
+    recipe do
+      command_line_tools 'horse'
+    end
+
+    it { is_expected.to run_execute('install Command Line Tools for Xcode-11.0') }
+  end
+
+  context 'with CLT installed' do
+    before(:each) do
+      allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib').and_return(true)
+    end
+
+    recipe do
+      command_line_tools 'no_description'
+    end
+
+    it { is_expected.to_not run_execute('install Command Line Tools for Xcode-11.0') }
   end
 end

--- a/test/integration/default/controls/command_line_tools_test.rb
+++ b/test/integration/default/controls/command_line_tools_test.rb
@@ -14,3 +14,11 @@ control 'command-line-tool-sentinel' do
     its('stdout') { should_not include 'Command Line Tools' }
   end
 end
+
+control 'xcrun' do
+  title 'xcrun binary installed by Command Line Tools'
+
+  describe file('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib') do
+    it { should exist }
+  end
+end


### PR DESCRIPTION
##This PR
- Improves the `command_line_tools` re-converge time by checking the `softwareupdate` install history before trying to query the full catalog from Apple, since most of the time this query was happening when tools were already installed. 

- Since `release/3.1.0` already has Catalina suites, I've also added support for the new `softwareupdate` catalog output in 10.15, fixing #202. Also, since Chef's current regex in `build_essential` (https://github.com/chef/chef/blob/be061344736b1f18bbdf52cae2e06c08407149d7/lib/chef/resource/build_essential.rb#L75) will have issues on Catalina output, I'm closing #206 since this resource supersedes functionality in Chef Infra. Stay tuned for updates about migrating this resource into `build_essential`.