### PR TITLE
Add upgrade action to command_line_tools resource

### DIFF
--- a/documentation/resource_command_line_tools.md
+++ b/documentation/resource_command_line_tools.md
@@ -24,7 +24,11 @@ The ``command_line_tools`` resource has the following actions:
 
 ``:install``
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default. Install the latest Xcode Command Line Tools.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Default. Install Command Line Tools from Apple. Takes no action if any version has previously been installed on the system. 
+
+``:upgrade``
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Check for an updated version of Command Line Tools and install them if available. 
 
 ``:nothing``
 

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -6,12 +6,11 @@ module MacOS
     attr_reader :version
 
     def initialize
-      if installed.empty?
-        enable_install_on_demand
-        @version = latest_from_catalog
-      else
-        @version = latest_installed
-      end
+      @version = if installed.empty?
+                   latest_from_catalog
+                 else
+                   latest_installed
+                 end
     end
 
     def installed
@@ -69,6 +68,7 @@ module MacOS
     end
 
     def softwareupdate_list
+      enable_install_on_demand
       shell_out(['softwareupdate', '--list']).stdout.lines
     end
 

--- a/resources/command_line_tools.rb
+++ b/resources/command_line_tools.rb
@@ -13,7 +13,28 @@ action :install do
     live_stream true
   end
 
-  file '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress' do
+  file 'sentinel to request on-demand install' do
+    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+    action :delete
+  end
+end
+
+action :upgrade do
+  file 'sentinel to request on-demand install' do
+    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+    action :create
+  end
+
+  command_line_tools = CommandLineTools.new
+
+  execute "upgrade #{command_line_tools.version}" do
+    command ['softwareupdate', '--install', command_line_tools.latest_from_catalog]
+    not_if { command_line_tools.version == command_line_tools.latest_from_catalog }
+    live_stream true
+  end
+
+  file 'sentinel to request on-demand install' do
+    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
     action :delete
   end
 end

--- a/resources/command_line_tools.rb
+++ b/resources/command_line_tools.rb
@@ -20,11 +20,6 @@ action :install do
 end
 
 action :upgrade do
-  file 'sentinel to request on-demand install' do
-    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
-    action :create
-  end
-
   command_line_tools = CommandLineTools.new
 
   execute "upgrade #{command_line_tools.version}" do

--- a/spec/unit/resources/command_line_tools_spec.rb
+++ b/spec/unit/resources/command_line_tools_spec.rb
@@ -38,3 +38,32 @@ describe 'command_line_tools' do
     it { is_expected.to_not run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
   end
 end
+
+describe 'command_line_tools' do
+  step_into :command_line_tools
+  platform 'mac_os_x'
+
+  context 'with a different version of command line tools than currently installed available' do
+    before do
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:softwareupdate_list)
+        .and_return(["Software Update Tool\n",
+                     "\n", "Finding available software\n",
+                     "Software Update found the following new or updated software:\n",
+                     "* Label: Command Line Tools for Xcode-22.0\n",
+                     "\tTitle: Command Line Tools for Xcode, Version: 22.0, Size: 224868K, Recommended: YES, \n"])
+      allow_any_instance_of(MacOS::CommandLineTools).to receive(:install_history_plist)
+        .and_return('spec/unit/libraries/data/InstallHistory_with_CLT.plist')
+    end
+
+    recipe do
+      command_line_tools 'always latest' do
+        action :upgrade
+      end
+    end
+
+    it {
+      is_expected.to run_execute('upgrade Command Line Tools for Xcode-11.0')
+        .with(command: ['softwareupdate', '--install', 'Command Line Tools for Xcode-22.0'])
+    }
+  end
+end

--- a/spec/unit/resources/command_line_tools_spec.rb
+++ b/spec/unit/resources/command_line_tools_spec.rb
@@ -11,24 +11,28 @@ describe 'command_line_tools' do
   end
 
   context 'without libxcrun present' do
-    before(:each) do
+    before do
       allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib').and_return(false)
     end
 
     recipe do
-      command_line_tools 'horse'
+      command_line_tools 'horse' do
+        action :install
+      end
     end
 
     it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
   end
 
   context 'with libxcrun present' do
-    before(:each) do
+    before do
       allow(File).to receive(:exist?).with('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib').and_return(true)
     end
 
     recipe do
-      command_line_tools 'no_description'
+      command_line_tools 'horse' do
+        action :install
+      end
     end
 
     it { is_expected.to_not run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }

--- a/test/cookbooks/macos_test/recipes/command_line_tools.rb
+++ b/test/cookbooks/macos_test/recipes/command_line_tools.rb
@@ -1,1 +1,7 @@
-command_line_tools 'install the latest'
+command_line_tools 'install them' do
+  action :install
+end
+
+command_line_tools 'upgrade them' do
+  action :upgrade
+end


### PR DESCRIPTION
## This PR
- Adds an `:upgrade` action to the `command_line_tools` resource. This action will check for an updated version of Command Line Tools and install them if available.