### PR TITLE
Fix platform detection in system library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.2.1] - 2020-03-03
+
+### Fixed
+
+- Fixed an issue with the `system` library where a system without hypervisor 
+software installed could be mistakenly identified as a VM and not have certain
+platform-specific power preferences set. 
+
 ## [3.2.0] - 2019-12-09
 
 ### Added

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ resources:
     name: chef-pipelines-templates
 
 jobs:
-- template: chefspec-cookstyle-foodcritic.yml@templates
+- template: chefspec-cookstyle.yml@templates
 - template: test-kitchen.yml@templates
   parameters:
     platforms:

--- a/libraries/system.rb
+++ b/libraries/system.rb
@@ -26,7 +26,7 @@ module MacOS
       end
 
       def vm?
-        @virtualization_systems.empty? || @virtualization_systems.value?('guest') ? true : false
+        @virtualization_systems.value?('guest') ? true : false
       end
     end
 

--- a/libraries/system.rb
+++ b/libraries/system.rb
@@ -26,7 +26,7 @@ module MacOS
       end
 
       def vm?
-        @virtualization_systems.value?('guest') ? true : false
+        @virtualization_systems.value?('guest')
       end
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '3.2.0'
+version '3.2.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/spec/unit/libraries/system_spec.rb
+++ b/spec/unit/libraries/system_spec.rb
@@ -63,7 +63,7 @@ describe MacOS::System::Environment do
   context 'setting virtualization_systems to empty' do
     it 'returns running in a vm' do
       env = MacOS::System::Environment.new({})
-      expect(env.vm?).to eq true
+      expect(env.vm?).to eq false
     end
   end
 

--- a/spec/unit/recipes/keep_awake_spec.rb
+++ b/spec/unit/recipes/keep_awake_spec.rb
@@ -80,44 +80,11 @@ shared_context 'running in a Parallels virtual machine' do
   end
 end
 
-shared_context 'running in an undetermined virtualization system' do
-  before(:each) do
-    chef_run.node.automatic['virtualization']['systems'] = {}
-    chef_run.node.automatic['hardware']['machine_model'] = ''
-  end
-
-  shared_examples 'ignoring metal-specific power preferences' do
-    it 'does not set wake on lan' do
-      chef_run.converge(described_recipe)
-      expect(chef_run).to_not set_system_preference('wake the computer when accessed using a network connection')
-    end
-
-    it 'skips disabling power button sleep' do
-      chef_run.converge(described_recipe)
-      expect(chef_run).to_not set_system_preference('pressing power button does not sleep computer')
-    end
-
-    it 'does not set restart after a power failure' do
-      chef_run.converge(described_recipe)
-      expect(chef_run).to_not set_system_preference('restart after a power failure')
-    end
-
-    it 'converges successfully in a vm' do
-      expect { chef_run }.to_not raise_error
-    end
-  end
-end
-
 describe 'macos::keep_awake' do
   let(:chef_run) { ChefSpec::SoloRunner.new }
 
   describe 'keep_awake in a Parallels VM' do
     include_context 'running in a Parallels virtual machine'
-    it_behaves_like 'ignoring metal-specific power preferences'
-  end
-
-  describe 'keep_awake in an undetermined virtualization system' do
-    include_context 'running in an undetermined virtualization system'
     it_behaves_like 'ignoring metal-specific power preferences'
   end
 


### PR DESCRIPTION
## [3.2.1] - 2020-03-03

### Fixed

- Fixed an issue with the `system` library where a system without hypervisor 
software installed could be mistakenly identified as a VM and not have certain
platform-specific power preferences set. 