### PR TITLE
Update command_line_tools library regex to support 11.0 productVersion (Big Sur)

### DIFF
--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -64,7 +64,7 @@ module MacOS
     end
 
     def macos_version
-      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/10\.\d+/]
+      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/1[01]\.\d+/]
     end
 
     def softwareupdate_list


### PR DESCRIPTION
---
name: Update command_line_tools library regex to support 11.0 productVersion (Big Sur)
about: The command_line_tools library regex to parse the productVersion from sw_vers only supports 10.* versions; this PR updates the regex to support 11.* as well for the latest Big Sur betas that are reporting 11.0 as the productVersion.
title: "Update command_line_tools library regex to support 11.0 productVersion (Big Sur)"
labels: ''
assignees: @jazaval 

---

## Describe the Pull Request  
The command_line_tools library regex to parse the productVersion from sw_vers only supports 10.* versions; this PR updates the regex to support 11.* as well for the latest Big Sur betas that are reporting 11.0 as the productVersion.

## Justification  
Fixes #224 