### PR TITLE
Add plist method to SystemPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.4.1] - 2020-09-25
+
+### Added
+
+- Added `plist` method to `SystemPath` library to match the methods in `UserPath`. 
+
 ## [3.4.0] - 2020-08-05
 
 ### Added

--- a/libraries/paths.rb
+++ b/libraries/paths.rb
@@ -40,6 +40,10 @@ module MacOS
       def preferences
         ::File.join(library, 'Preferences')
       end
+
+      def plist(plist)
+        ::File.join(preferences, plist)
+      end
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '3.4.0'
+version '3.4.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/spec/unit/libraries/paths_spec.rb
+++ b/spec/unit/libraries/paths_spec.rb
@@ -44,5 +44,9 @@ describe MacOS::SystemPath, 'SystemPath library helper functions' do
     it 'preferences creates the correct system preferences path' do
       expect(SystemPath.preferences).to eq '/Library/Preferences'
     end
+
+    it 'plist creates the correct system preferences plist path' do
+      expect(SystemPath.plist('com.apple.screensaver.plist')).to eq '/Library/Preferences/com.apple.screensaver.plist'
+    end
   end
 end


### PR DESCRIPTION
---
name: Pull Request
about: File a pull request to help us improve
title: "[PR]"
labels: ''
assignees: ''

---

## Describe the Pull Request  
Looks like we missed the `plist` method when writing the SystemPath library. 

Added `plist` to match what we have in the `UserPath` library to make it easy to access any plist files in `/Library/Preferences/plistfilehere.plist`

## Justification  
Several custom resources involve manipulation of plist files contained within the /Library/Preferences directory. Would be useful to have this method as opposed to having to do a 

```::File.join SystemPath.preferences 'com.apple.something.plist'```