### PR TITLE
Fix parsing of 'xcversion list' output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Fixed
 
-- Fixed `xcversion` library `list` output to not include "(installed)" status, since this is determined separately in the `xcode` resource. The additional string content was breaking parsing that prevents installation on non-complete Xcode bundles such as `12 for macOS Universal Apps`.
+- Updated `xcversion` library `list` output to not include "(installed)" status, since this is determined separately in the `xcode` resource. The additional string content was breaking parsing that prevents installation on non-complete Xcode bundles such as `12 for macOS Universal Apps`.
 
 - Fixes for Cookstyle version: 7.7.2
+
+### Removed
+
+- Removed ChefSpec testing on deprecated Fauxhai platforms
 
 ## [3.4.1] - 2020-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,24 +12,24 @@
 
 ### Added
 
-- Added `plist` method to `SystemPath` library to match the methods in `UserPath`. 
+- Added `plist` method to `SystemPath` library to match the methods in `UserPath`.
 
 ## [3.4.0] - 2020-08-05
 
 ### Added
 
 - Support and testing for Big Sur. Due to a bug in the `kickstart` script in Big Sur, the `remote_management`
-resource is not functional on any system that reports `11.0` instead of `10.16`, which is the case
-on 20A5323l (beta 3) or later. This will be resolved at a later date. 
+  resource is not functional on any system that reports `11.0` instead of `10.16`, which is the case
+  on 20A5323l (beta 3) or later. This will be resolved at a later date.
 
 - Deprecation notice for `macos::keep_awake`.
 
 ### Fixed
 
-- The `xcode` resource now installs the latest available beta revision or GM seed of Xcode if there 
-is not an official release of the requested version. Note that installing the early "Xcode 12 for macOS 
-Universal Apps" betas is not supported since Apple has already unified these into the core Xcode
-bundles as of 12A8169g (beta 3).
+- The `xcode` resource now installs the latest available beta revision or GM seed of Xcode if there
+  is not an official release of the requested version. Note that installing the early "Xcode 12 for macOS
+  Universal Apps" betas is not supported since Apple has already unified these into the core Xcode
+  bundles as of 12A8169g (beta 3).
 
 - The `macos_user` resource now prevents the screen from re-locking at boot when auto-login is enabled.
 
@@ -46,7 +46,7 @@ bundles as of 12A8169g (beta 3).
 ### Fixed
 
 - Fixed an issue where the beta version of Xcode would be installed over the GM
-version if both were still available from Apple. 
+  version if both were still available from Apple.
 - Updated the Xcode OS platform compatibility logic. Thanks @nickdowell!
 - Numerous cookstyle fixes.
 
@@ -58,9 +58,9 @@ version if both were still available from Apple.
 
 ### Fixed
 
-- Fixed an issue with the `system` library where a system without hypervisor 
-software installed could be mistakenly identified as a VM and not have certain
-platform-specific power preferences set. 
+- Fixed an issue with the `system` library where a system without hypervisor
+  software installed could be mistakenly identified as a VM and not have certain
+  platform-specific power preferences set.
 
 ## [3.2.0] - 2019-12-09
 
@@ -92,6 +92,7 @@ platform-specific power preferences set.
 ## [3.0.9] - 2019-09-11
 
 ### Fixed
+
 - Fixed an issue where the Xcode resource cannot find the Xcode 11 GM bundle path to move it to the declared path in the resource. It removes a logic tree in favor of matching the behavior of the xcode-install gem: https://github.com/xcpretty/xcode-install/blob/74b89805462d6795d964935239f78e6d2790a52d/lib/xcode/install.rb#L282, which is to replace spaces in the version listed by Apple with a period.
 
 - Fixed an issue where installing the xcode-install gem fails on Chef 15
@@ -101,6 +102,7 @@ platform-specific power preferences set.
 ## [3.0.8] - 2019-07-31
 
 ### Fixed
+
 - Fixed an issue where Xcode versions containing whitespace were not properly quoted in command execution. Regression from version 2.10 release.
 
 ## [3.0.1] - 2019-03-15
@@ -108,24 +110,29 @@ platform-specific power preferences set.
 Thanks to @jkronborg for these two fixes!
 
 ### Fixed
+
 - Fixed a guard in `keep_awake` for use on portables.
 - Fixed incorrect attribute key in the Xcode resource documentation, and added a security suggestion.
 
 ## [3.0.0] - 2019-02-28
 
 ### Added
+
 - Added `automatic_software_updates` resource to enable or disable the automatic checking, downloading, and installing of software updates.
 - Added `azure-pipelines.yml` to allow for managing builds as code.
 - Added some resource unit tests for `spotlight` to complement the existing `metadata_util` tests.
 
 ### Changed
+
 - Changed the `ard` resource to `remote_management` and updates applicable tests and documentation. The new `remote_management` resource greatly simplifies syntax and reduces the needed macOS domain knowledge around `kickstart` options. However, it has less functionality than `ard` and is a significant breaking change.
 
 ### Fixed
+
 - Fixed .mailmap file to accurately track contributor emails.
 - Fixed guard in the `keychain` resource for the `:create` action.
 
 ### Removed
+
 - Adiós, Captain! We no longer support OS X El Capitan or Chef 13.
 - Removed `machine_name` resource along with respective tests and documentation in favor of the `hostname` resource in Chef 14.
 - Removed `xcode` recipe along with respective tests, documentation and node attributes in favor of `command_line_tools` resource which was released in 2.10.0.
@@ -135,6 +142,7 @@ Thanks to @jkronborg for these two fixes!
 ## [2.10.1] - 2019-01-29
 
 ### Fixed
+
 - Fixed issue in which setting certain `machine_name` resource properties (`hostname`, `local_hostname`, `dns_domain`) from a previously unset state, would fail to compile. ([Issue #181](https://github.com/Microsoft/macos-cookbook/issues/181)).
 
 ## [2.10.0] - 2019-01-16
@@ -181,166 +189,221 @@ Thanks to @jkronborg for these two fixes!
 ### Added
 
 - Multi-converge testing added for all kitchen suites, idempotency enforced for select resources. Idempotency issues identified and resolved with the `keep_awake` recipe, the `spotlight` resource, and the `ard` resource
-as a result. More enforcing by the idempotence police to come in future releases.
+  as a result. More enforcing by the idempotence police to come in future releases.
 
 ### Removed
+
 - Removal of dead links in documentation for resources to allow for more up to date and clear documentation. ([Issue #129](https://github.com/Microsoft/macos-cookbook/issues/129)).
 
 ### Fixed
+
 - Resolved an issue with the `ard` resource where a Chef run sometimes fails due to an intermittent `kickstart` failure. Guards added to the default resource actions to prevent this issue. ([Issue #70](https://github.com/Microsoft/macos-cookbook/issues/70)).
 - Resolved an issue with the `spotlight` resource where `mdutil` output was improperly parsed and
-`mdutil` commands were re-ran when not needed.
+  `mdutil` commands were re-ran when not needed.
 
 ## [2.6.1] - 2018-10-04
+
 ### Added
+
 - The desert took its toll, the README now declares support for Mojave!
 
 ## [2.6.0] - 2018-10-03
+
 ### Added
+
 - Apple has limited some kickstart command functionality in macOS Mojave, preventing screen
-control in some invocations. We verified the `ard` resource's implementation of the `kickstart` script still functions.
+  control in some invocations. We verified the `ard` resource's implementation of the `kickstart` script still functions.
 
 - Updated Xcode default version to 10.0.
 
 - The team crossed the great Mojave Desert, collapsed from dehydration, all just to obtain its support. In other words we now support macOS Mojave.
 
 ### Fixed
+
 - Prevented the `xcode` resource from leaving available Command Line Tools downloads
-in Software Updates.
+  in Software Updates.
 
 ### Deprecated
+
 - The `machine_name` resource has been deprecated in favor of the macOS support in the `hostname` resource in Chef 14. It will be removed in the release of v3.0 of the macOS cookbook.
 
 ## [2.5.0] - 2018-09-10
+
 ### Added
+
 - Added `CHANGELOG.md`, About time right? ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).
 - Added functional `path` property to Xcode resource. ([Issue #116](https://github.com/Microsoft/macos-cookbook/issues/116)).
 - Added ChefSpec resource tests for Xcode.
 
 ### Fixed
+
 - Separated extra responsibilities of Xcode resource into DeveloperAccount and
-CommandLineTools libraries.
+  CommandLineTools libraries.
 
 ## [2.4.0] - 2018-08-16
+
 ### Added
+
 - Added `CHANGELOG.md`. ([Issue #122](https://github.com/Microsoft/macos-cookbook/issues/122)).
 
 ### Removed
+
 - `homebrew` cookbook dependency removed. `homebrew_cask` and `homebrew_tap` is being deprecated by Chef and has not been used by `macos-cookbook` since version `2.0`. ([Issue #123](https://github.com/Microsoft/macos-cookbook/issues/123)).
 
 ### Fixed
+
 - Fixed `keychain` resource documentation link.
 - Update `metadata_util` library to consider Spotlight server status before manipulating indexing state. ([Issue #45](https://github.com/Microsoft/macos-cookbook/issues/45)).
 
 ## [2.3.0] - 2018-06-28
+
 ### Added
+
 - Like a trained ninja of the night, the `macos_user` now has a `hidden` property, making it impossible to detect from the login screen.
 - Moved to a new set of internal Vagrant macOS boxes, which have much more minimal initial configuration. This ensures that our resources run from a more out-of-the-box macOS experience.
 
 ### Fixed
+
 - Fixed bug where deletion of a user was failing when using the macos_user resource.
 - For those of you who like to set their user and password as the same characters, we fixed an issue in the certificate resource for non-Vagrant use cases, you know for normal human beings who like a secure environment.
 
 ## [2.2.0] - 2018-05-29
+
 ### Added
+
 - Foodcritics can be pretty harsh in their critiquing of food. They also have some pretty in depth rules we need to comply with, so we updated machine_name to comply with the new FoodCritic rule FC115.
 - Added guard config to automatically run relevant unit tests when a file is changed.
 - Update to InSpec control filenames to match the standard. This allows for better understanding of the tests.
 
 ## [2.1.0] - 2018-05-16
+
 ### Added
+
 - Created an autologin functionality on 10.13.4 to allow for machine to automatically login to the machine.
 
 ## [2.0.0] - 2018-05-09
+
 ### Removed
+
 - Removed the Mono recipe as it is not in the scope of this cookbook.
 - Removed Apple Configurator recipe as a bug with the `mas` dependency does not function in High Sierra.
 
 ## [1.14.0] - 2018-05-01
+
 ### Added
+
 - Updated the `keep_awake` recipe and spec tests to not require node attribute stubbing when wrapped in another cookbook.
 
 ## [1.13.0] - 2018-04-25
+
 ### Added
+
 - Added a CONTRIBUTING.md to outline the Chef Community Guidelines for code contribution.
 
 ### Fixed
+
 - Fixed an issue with ChefSpec when wrapping the `keep_awake` recipe.
 - Fixed an idempotence issue with the keychain resource.
 
 ## [1.12.0] - 2018-04-16
+
 ### Added
+
 - Added new keychain resource
 - Introduced three new library classes `Power`, `Environment`, and `ScreenSaver`.
 - Updated README.md to reflect single build definition.
 - Added feature to make disk sleep default to `Never`.
 
 ## [1.11.0] - 2018-04-11
+
 ### Added
+
 - Added the ability to install Xcode beta builds to the `xcode` resource.
 - Added support for Chef 14.
 
 ## [1.10.0] - 2018-03-26
+
 ### Added
+
 - Added feature that allows node attributes to be set for Developer Apple ID credentials while downloading Xcode from Apple.
 - Added ability to install Command Line tools from the `xcode-install` gem.
 
 ### Fixed
+
 - Increased timeout for Xcode download for issue where method `bundle_version_correct` fails and unsuccessfully tries to access node attributes in Xcode library.
 - Resolved issue where adding users and groups would fail tests.
 
 ## [1.9.0] - 2018-03-21
+
 ### Added
+
 - Added support for other hypervisors and keep away logic.
 - Implemented `-t` option in `certificate` resource to allow apps to access imported key.
 - Add `utf-8` encoding type to `plist` resource to make it more robust.
 
 ## [1.8.0] - 2018-03-12
+
 ### Added
+
 - Added a `dns_domain` property to `machine_name` resource to support FQDNs.
 - Added TESTING.md documentation.
 - Changed `binary` property to `encoding` to support xml and binary plist formats.
 
 ### Removed
+
 - Removed support for `NetBIOSName` due to macOS bugs.
 
 ### Fixed
+
 - Fixed several bugs in `plist` resource.
 - Fixed typos in `machine_name` resource documentation.
 
 ## [1.7.0] - 2018-03-05
+
 ### Added
+
 - Added the `certificate` resource, this resource manages the state of a given certificate for a specified keychain.
 
 ## [1.6.0] - 2018-02-20
+
 ### Added
+
 - Added whitespace support for property list names and keys.
 
 ### Fixed
+
 - Fixed some depreciation bugs in the `macos_user` resource.
 - Fixed idempotency bug in `.kitchen.yml`.
 
 ## [1.5.0] - 2018-02-12
+
 ### Added
+
 - Added new `system_preference` resource.
 
 ### Removed
+
 - Removed `systemsetup` resource.
 - Removed `.delivery` in favor of `kitchen test` and concurrency testing model.
 
 ### Fixed
+
 - Fixed issue where `plist` resources cause incomplete idempotence on second converge by making the `keep_awake` recipe idempotent. ([Issue #15](https://github.com/Microsoft/macos-cookbook/issues/15)).
 - Fixed issue where `macos_user` was not allowing users to be added to groups by creating a new `groups` property. ([Issue #40](https://github.com/Microsoft/macos-cookbook/issues/40)).
 - Fixed issue where `machine_name` resource does not set `LocalHostName` by making `machine_name` idempotent and having it properly set the `LocalHostName`. ([Issue #20](https://github.com/Microsoft/macos-cookbook/issues/20)).
 
 ## [1.3.0] - 2018-02-02
+
 ### Added
+
 - Added helper modules for `systemsetup`.
 - Added new attributes to adjust the `keep_awake` functions.
 - Added better functionality to the `keep_awake` power resources.
 
 ### [1.2.0] - 2018-01-28
+
 ### Added
+
 - Initial release of the macOS Cookbook.
 - Chef support for 10.10 to 10.13.
 - Added `xcode` resource.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.4.2] - 2020-02-10
+
+### Fixed
+
+- Fixed `xcversion` library `list` output to not include "(installed)" status, since this is determined separately in the `xcode` resource. The additional string content was breaking parsing that prevents installation on non-complete Xcode bundles such as `12 for macOS Universal Apps`.
+
+- Fixes for Cookstyle version: 7.7.2
+
 ## [3.4.1] - 2020-09-25
 
 ### Added

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,14 +34,14 @@ platforms:
 - name: catalina-chef16
   driver:
     box: microsoft/macos-catalina
-    box_version: 10.15.6
+    box_version: 10.15.7
   provisioner:
     product_version: 16
 
 - name: big-sur-chef16
   driver:
     box: microsoft/macos-big-sur
-    box_version: 11.0.0-20A5343i
+    box_version: 11.2.1
   provisioner:
     product_version: 16
 

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -78,5 +78,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS)
+Chef::DSL::Recipe.include(MacOS)
 Chef::Resource.include(MacOS)

--- a/libraries/developer_account.rb
+++ b/libraries/developer_account.rb
@@ -35,5 +35,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS)
+Chef::DSL::Recipe.include(MacOS)
 Chef::Resource.include(MacOS)

--- a/libraries/macos_user.rb
+++ b/libraries/macos_user.rb
@@ -32,5 +32,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS::MacOSUserHelpers)
+Chef::DSL::Recipe.include(MacOS::MacOSUserHelpers)
 Chef::Resource.include(MacOS::MacOSUserHelpers)

--- a/libraries/metadata_util.rb
+++ b/libraries/metadata_util.rb
@@ -21,5 +21,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS)
+Chef::DSL::Recipe.include(MacOS)
 Chef::Resource.include(MacOS)

--- a/libraries/plist.rb
+++ b/libraries/plist.rb
@@ -121,7 +121,5 @@ module MacOS
     end
   end
 end
-
-Chef::Recipe.include MacOS::PlistHelpers
 Chef::Resource.include MacOS::PlistHelpers
 Chef::DSL::Recipe.include MacOS::PlistHelpers

--- a/libraries/remote_management.rb
+++ b/libraries/remote_management.rb
@@ -35,5 +35,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS)
+Chef::DSL::Recipe.include(MacOS)
 Chef::Resource.include(MacOS)

--- a/libraries/security_cmd.rb
+++ b/libraries/security_cmd.rb
@@ -67,5 +67,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS)
+Chef::DSL::Recipe.include(MacOS)
 Chef::Resource.include(MacOS)

--- a/libraries/software_updates.rb
+++ b/libraries/software_updates.rb
@@ -17,5 +17,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS::SoftwareUpdates)
+Chef::DSL::Recipe.include(MacOS::SoftwareUpdates)
 Chef::Resource.include(MacOS::SoftwareUpdates)

--- a/libraries/system.rb
+++ b/libraries/system.rb
@@ -44,7 +44,5 @@ module MacOS
     end
   end
 end
-
-Chef::Recipe.include(MacOS::System)
 Chef::Resource.include(MacOS::System)
 Chef::DSL::Recipe.include(MacOS::System)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -63,6 +63,7 @@ module MacOS
       return '>= 10.14.4' if Gem::Dependency.new('Xcode', '>= 11.0', '<= 11.3.1').match?('Xcode', @semantic_version)
       return '>= 10.15.2' if Gem::Dependency.new('Xcode', '>= 11.4').match?('Xcode', @semantic_version)
     end
+
     class Simulator
       attr_reader :version
 
@@ -174,5 +175,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS)
+Chef::DSL::Recipe.include(MacOS)
 Chef::Resource.include(MacOS)

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -53,6 +53,7 @@ module MacOS
       def available_versions
         lines = shell_out!(XCVersion.list_available_xcodes).stdout.lines
         lines.reject { |line| line.start_with?(/\D/) }
+        lines.map { |line| line.chomp(' (installed)') }
       end
     end
   end

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -52,7 +52,7 @@ module MacOS
 
       def available_versions
         lines = shell_out!(XCVersion.list_available_xcodes).stdout.lines
-        lines.reject { |line| line.start_with?(/\D/) }
+        lines.reject! { |line| line.start_with?(/\D/) }
         lines.map { |line| line.chomp('(installed)').strip }
       end
     end

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -53,7 +53,7 @@ module MacOS
       def available_versions
         lines = shell_out!(XCVersion.list_available_xcodes).stdout.lines
         lines.reject { |line| line.start_with?(/\D/) }
-        lines.map { |line| line.chomp(' (installed)') }
+        lines.map { |line| line.chomp('(installed)').strip }
       end
     end
   end

--- a/libraries/xcversion.rb
+++ b/libraries/xcversion.rb
@@ -59,5 +59,5 @@ module MacOS
   end
 end
 
-Chef::Recipe.include(MacOS)
+Chef::DSL::Recipe.include(MacOS)
 Chef::Resource.include(MacOS)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '3.4.1'
+version '3.4.2'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -15,10 +15,10 @@ action :install do
   cert = SecurityCommand.new(new_resource.certfile, keychain)
 
   execute 'unlock keychain' do
-    command [*cert.unlock_keychain(node['macos']['admin_password'])]
+    command Array(cert.unlock_keychain(node['macos']['admin_password']))
   end
 
   execute 'install-certificate' do
-    command [*cert.install_certificate(new_resource.cert_password, new_resource.apps)]
+    command Array(cert.install_certificate(new_resource.cert_password, new_resource.apps))
   end
 end

--- a/resources/keychain.rb
+++ b/resources/keychain.rb
@@ -14,7 +14,7 @@ action :create do
   keyc = SecurityCommand.new('', keychain)
 
   execute 'create a keychain' do
-    command [*keyc.create_keychain(new_resource.kc_passwd)]
+    command Array(keyc.create_keychain(new_resource.kc_passwd))
     not_if { ::File.exist? keychain + '-db' }
   end
 end
@@ -22,7 +22,7 @@ end
 action :delete do
   keyc = SecurityCommand.new('', keychain)
   execute 'delete selected keychain' do
-    command [*keyc.delete_keychain]
+    command Array(keyc.delete_keychain)
     only_if { ::File.exist?(keychain) }
   end
 end
@@ -30,14 +30,14 @@ end
 action :lock do
   keyc = SecurityCommand.new('', keychain)
   execute 'lock selected keychain' do
-    command [*keyc.lock_keychain]
+    command Array(keyc.lock_keychain)
     only_if { ::File.exist?(keychain) }
   end
 end
 
 action :unlock do
   keyc = SecurityCommand.new('', keychain) do
-    command [*keyc.unlock_keychain(new_resource.kc_passwd)]
+    command Array(keyc.unlock_keychain(new_resource.kc_passwd))
     only_if { ::File.exist?(keychain) }
   end
 end

--- a/spec/unit/resources/spotlight_spec.rb
+++ b/spec/unit/resources/spotlight_spec.rb
@@ -4,7 +4,7 @@ describe 'macos::spotlight' do
   step_into :spotlight
 
   context 'Spotlight resource converges successfully' do
-    platform 'mac_os_x', 10.13
+    platform 'mac_os_x', 10.15
 
     recipe do
       spotlight 'test' do


### PR DESCRIPTION
# Changelog

## [3.4.2] - 2020-02-10

### Fixed

- Updated `xcversion` library `list` output to not include "(installed)" status, since this is determined separately in the `xcode` resource. The additional string content was breaking parsing that prevents installation of non-complete Xcode bundles such as `12 for macOS Universal Apps`.

- Fixes for Cookstyle version: 7.7.2

### Removed

- Removed ChefSpec testing on deprecated Fauxhai platforms