### PR TITLE
v4.1.1 – Use Unified Mode in all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [4.0.1] - 2020-06-04
+
+### Changed
+
+- Bump all suites except macOS High Sierra to Chef 17
+
+### Added
+
+- Added `unified_mode true` to all resources. See [Unified Mode in Custom Resources][unified-mode-in-custom-resources]
+  for more information.
+
 ## [4.0.0] - 2020-02-25
 
 ### Removed
@@ -429,3 +440,5 @@ Thanks to @jkronborg for these two fixes!
 - Added `spotlight` resource.
 - Added `machine_name` resource.
 - Added `macos_user` resource.
+
+[unified-mode-in-custom-resources]: https://docs.chef.io/release_notes_client/#unified-mode-in-custom-resources

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '4.0.0'
+version '4.0.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/automatic_software_updates.rb
+++ b/resources/automatic_software_updates.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :automatic_software_updates
 
 property :check, [true, false]

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :certificate
 
 property :certfile, String

--- a/resources/command_line_tools.rb
+++ b/resources/command_line_tools.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :command_line_tools
 
 property :compile_time, [true, false],

--- a/resources/defaults.rb
+++ b/resources/defaults.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :defaults
 
 property :domain, String, name_property: true

--- a/resources/keychain.rb
+++ b/resources/keychain.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :keychain
 default_action :create
 

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :macos_user
 default_action :create
 

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :plist
 
 property :path, String, name_property: true

--- a/resources/pmset.rb
+++ b/resources/pmset.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :pmset
 default_action :run
 

--- a/resources/remote_management.rb
+++ b/resources/remote_management.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :remote_management
 default_action :enable
 

--- a/resources/spotlight.rb
+++ b/resources/spotlight.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :spotlight
 default_action :set
 

--- a/resources/system_preference.rb
+++ b/resources/system_preference.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :system_preference
 
 property :preference, Symbol, required: true, desired_state: false

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 provides :xcode
 default_action %i(install_gem install_xcode install_simulators)
 


### PR DESCRIPTION
## This PR

- Adds Chef 17 notes to CHANGELOG
- Adds `unified_mode true` to all resources. See [Unified Mode in Custom Resources][unified-mode-in-custom-resources]
  for more information.

## Why

- Resolves deprecation warnings about unified mode when using Chef 17. Without `unified_mode true`, the following deprecation warning is received (it's real noisy):

```
  The automatic_software_updates resource in the macos cookbook should declare `unified_mode true` at 1 location:
    - /private/var/folders/6h/5602xjnn6rb7l3lr0str3hw00000gn/T/tmp.qdK9JILL/.chef/local-mode-cache/cache/cookbooks/macos/resources/automatic_software_updates.rb
   See https://docs.chef.io/deprecations_unified_mode/ for further details.
```

...and so on for all of the cookbook's resources.

Although `unified_mode` isn't strictly required for Chef 17, it will save some headache in 2022 when it is required by Chef 18.

[unified-mode-in-custom-resources]: https://docs.chef.io/release_notes_client/#unified-mode-in-custom-resources