### PR TITLE
Add support for macOS Monterey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [4.2.0] - 2020-06-09
+
+### Added
+
+- Added basic support and testing for macOS Monterey.
+
+### Removed
+
+- Removed testing and official support for macOS High Sierra.
+- Removed testing and official support for Chef 16.
+
+### Fixed
+
+- The `command_line_tools` OS version parsing regex has been fixed for the new macOS versioning scheme.
+
 ## [4.1.0] - 2020-06-07
 
 ### Added

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,10 +47,10 @@ jobs:
 - template: test-kitchen.yml@templates
   parameters:
     platforms:
-    - high-sierra-chef16
     - mojave-chef17
     - catalina-chef17
     - big-sur-chef17
+    - monterey-chef17
     suites:
     - default
     - software-updates

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,13 +17,6 @@ verifier:
   - test/integration/default
 
 platforms:
-- name: high-sierra-chef16
-  driver:
-    box: microsoft/macos-high-sierra
-    box_version: 10.13.6
-  provisioner:
-    product_version: 16
-
 - name: mojave-chef17
   driver:
     box: microsoft/macos-mojave
@@ -41,7 +34,14 @@ platforms:
 - name: big-sur-chef17
   driver:
     box: microsoft/macos-big-sur
-    box_version: 11.2.1
+    box_version: 11.4
+  provisioner:
+    product_version: 17
+
+- name: monterey-chef17
+    driver:
+      box: microsoft/macos-big-sur
+      box_version: 12.0-21A5248p
   provisioner:
     product_version: 17
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -40,7 +40,7 @@ platforms:
 
 - name: monterey-chef17
   driver:
-    box: microsoft/macos-big-sur
+    box: microsoft/macos-monterey
     box_version: 12.0-21A5248p
   provisioner:
     product_version: 17

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -39,9 +39,9 @@ platforms:
     product_version: 17
 
 - name: monterey-chef17
-    driver:
-      box: microsoft/macos-big-sur
-      box_version: 12.0-21A5248p
+  driver:
+    box: microsoft/macos-big-sur
+    box_version: 12.0-21A5248p
   provisioner:
     product_version: 17
 

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -64,7 +64,7 @@ module MacOS
     end
 
     def macos_version
-      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/1[01]\.\d+/]
+      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/1[\d]\.\d+/]
     end
 
     def softwareupdate_list

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '4.1.1'
+version '4.1.2'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '4.1.2'
+version '4.2.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'


### PR DESCRIPTION
## [4.2.0] - 2020-06-09

### Added

- Added basic support and testing for macOS Monterey.

### Removed

- Removed testing and official support for macOS High Sierra.
- Removed testing and official support for Chef 16.

### Fixed

- The `command_line_tools` OS version parsing regex has been fixed for the new macOS versioning scheme.