### PR TITLE
enforce password property sensitivity for macos_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.2.3] - 2022-02-03
+
+### Fixed
+
+- Enforce sensitivity for the `macos_user` resource `password` property as a security measure. This prevents downstream users from needing to declare `sensitive true` on the resource call.
+
 ## [4.2.2] - 2021-10-18
 
 ### Fixed

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '4.2.2'
+version '4.2.3'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -4,7 +4,7 @@ provides :macos_user
 default_action :create
 
 property :username, String, name_property: true
-property :password, String, default: 'password'
+property :password, String, sensitive: true
 property :autologin, [TrueClass]
 property :admin, [TrueClass]
 property :fullname, String
@@ -81,6 +81,7 @@ end
 action :create do
   execute "add user #{new_resource.username}" do
     command [sysadminctl, *admin_credentials, '-addUser', new_resource.username, *user_fullname, '-password', new_resource.password, admin_user]
+    sensitive true
     not_if { ::File.exist?(user_home) && user_already_exists? }
   end
 
@@ -136,6 +137,7 @@ action :create do
       owner 'root'
       group 'wheel'
       mode '0600'
+      sensitive true
     end
   end
 


### PR DESCRIPTION
## [4.2.3] - 2022-02-03

### Fixed

- Enforce sensitivity for the `macos_user` resource `password` property as a security measure. This prevents downstream users from needing to declare `sensitive true` on the resource call.