### PR TITLE
Certificate wrong order for .cer fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.3.0] - 2022-02-18
+
+### Fixed
+- Reversed order of arguments for certificate installation to address [Bug 244](https://github.com/microsoft/macos-cookbook/issues/244). 
+
+### Added
+- New test suites and recipe change to account for `.cer` files. 
+
 ## [4.2.3] - 2022-02-03
 
 ### Fixed

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -102,6 +102,8 @@ suites:
     - xcrun
 
 - name: certificate
+  provisioner:
+    multiple_converge: 1
   run_list:
   - recipe[macos_test::certificate]
   verifier:

--- a/libraries/security_cmd.rb
+++ b/libraries/security_cmd.rb
@@ -33,7 +33,7 @@ module MacOS
     end
 
     def add_certificates
-      @keychain.empty? ? [@security_cmd, 'add-certificates', @cert] : [@security_cmd, 'add-certificates', @cert, '-k', @keychain]
+      @keychain.empty? ? [@security_cmd, 'add-certificates', @cert] : [@security_cmd, 'add-certificates', '-k', @keychain, @cert]
     end
 
     def import(cert_passwd, apps)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '4.2.3'
+version '4.3.0'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/spec/unit/libraries/security_cmd_spec.rb
+++ b/spec/unit/libraries/security_cmd_spec.rb
@@ -63,7 +63,7 @@ describe MacOS::SecurityCommand, 'certificate creation commands' do
 
   context 'adding a certificate (.cer) to a certain keychain' do
     it 'adds a specified .cer certificate file' do
-      expect(cer_cert_kc.add_certificates).to eq ['/usr/bin/security', 'add-certificates', '/Users/vagrant/Test.cer', '-k', 'test.keychain']
+      expect(cer_cert_kc.add_certificates).to eq ['/usr/bin/security', 'add-certificates', '-k', 'test.keychain', '/Users/vagrant/Test.cer']
     end
   end
 

--- a/test/cookbooks/macos_test/recipes/certificate.rb
+++ b/test/cookbooks/macos_test/recipes/certificate.rb
@@ -1,12 +1,40 @@
+foobar_pem_path = '/Users/vagrant/foobar.pem'
+foobar_cer_path = '/Users/vagrant/foobar.cer'
+
 cookbook_file '/Users/vagrant/Test.p12' do
   action :create
   source 'Test.p12'
 end
 
+keychain 'test' do
+  kc_file '/Users/vagrant/Library/Keychains/test.keychain'
+  kc_passwd 'test'
+  action :create
+end
+
+openssl_x509_certificate foobar_pem_path do
+  common_name 'www.f00bar.com'
+  org 'Foo Bar'
+  org_unit 'Lab'
+  country 'US'
+end
+
+execute 'convert .pem certificate to .cer certificate' do
+  command ['/usr/bin/openssl', 'x509', '-inform', 'PEM', '-in', foobar_pem_path, '-outform', 'DER', '-out', foobar_cer_path]
+  only_if { ::File.exist? foobar_pem_path }
+end
+
+certificate 'install a .cer format certificate file' do
+  certfile foobar_cer_path
+  keychain '/Users/vagrant/Library/Keychains/login.keychain'
+  apps ['/Applications/Numbers.app']
+  action :install
+end
+
 certificate 'install a PFX format certificate file' do
   certfile '/Users/vagrant/Test.p12'
   cert_password 'test'
-  keychain '/Users/vagrant/Library/Keychains/login.keychain'
+  keychain '/Users/vagrant/Library/Keychains/test.keychain'
   apps ['/Applications/Safari.app']
   action :install
 end

--- a/test/integration/default/controls/security_test.rb
+++ b/test/integration/default/controls/security_test.rb
@@ -11,8 +11,16 @@ control 'certificate-install' do
     it { should exist }
   end
 
-  describe command('/usr/bin/security find-certificate /Users/vagrant/Library/Keychains/login.keychain') do
+  describe file('/Users/vagrant/foobar.cer') do
+    it { should exist }
+  end
+
+  describe command('/usr/bin/security find-certificate /Users/vagrant/Library/Keychains/test.keychain') do
     its('stdout') { should include 'Test' }
+  end
+
+  describe command('/usr/bin/security find-certificate /Users/vagrant/Library/Keychains/login.keychain') do
+    its('stdout') { should include 'f00bar' }
   end
 end
 


### PR DESCRIPTION
---
name: Pull Request
about: File a pull request to help us improve
title: "[PR]"
labels: ''
assignees: ''

---

## Describe the Pull Request  
A clear and concise description of what the Pull Request aims to do. 
## [4.3.0] - 2022-02-18

- Reversed order of arguments for certificate installation to address [Bug 244](https://github.com/microsoft/macos-cookbook/issues/244) when dealing with `.cer` certificates. The original code only dealt with .p12 examples. 
- New test suites and recipe change to account for `.cer` files. 


## Justification  
A clear and concise description of issues the Pull Requests solves if any.
- Reversed order of arguments for certificate installation to address [Bug 244](https://github.com/microsoft/macos-cookbook/issues/244). 
- Also provides examples on how to generate these certificates for testing