### PR TITLE
QOL Improvment: Remove dependency on attribute and use property instead for keychain password in certificate resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-## [4.3.0] - 2022-02-18
+## [4.3.0] - 2022-02-25
 
 ### Fixed
 - Reversed order of arguments for certificate installation to address [Bug 244](https://github.com/microsoft/macos-cookbook/issues/244). 
 
 ### Added
 - New test suites and recipe change to account for `.cer` files. 
+- New certificate resource property: kc_passwd which allows setting of keychain password. 
+- Updated certificate resource documentation
+
+### Changed
+- Removed dependency on using the `default['macos']['admin_password']` attribute for setting the keychain password when using the certificate resource. 
 
 ## [4.2.3] - 2022-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog
 
-## [4.3.0] - 2022-02-25
+## [4.3.0] - 2022-03-04
 
 ### Fixed
 - Reversed order of arguments for certificate installation to address [Bug 244](https://github.com/microsoft/macos-cookbook/issues/244). 
 
 ### Added
 - New test suites and recipe change to account for `.cer` files. 
-- New certificate resource property: kc_passwd which allows setting of keychain password. 
-- Updated certificate resource documentation
+- New certificate resource property: kc_passwd which allows setting of keychain password. Not putting in a password will revert back to using 
+  the `['macos']['admin_password']` attribute. 
+- Check for certificate existence within the keychain before installing a new one to ensure idempotency. 
+- Made password properties sensitive. 
+- Updated certificate resource documentation.
 
 ### Changed
 - Removed dependency on using the `default['macos']['admin_password']` attribute for setting the keychain password when using the certificate resource. 

--- a/documentation/resource_certificate.md
+++ b/documentation/resource_certificate.md
@@ -3,7 +3,7 @@ certificate
 
 Use the **certificate** resource to manage certificates for keychains.
 Under the hood, the [**certificate**](https://github.com/Microsoft/macos-cookbook/blob/master/resources/certificate.rb) resource executes the `security`
-command in the `security_cmd` library.
+command in the [**security_cmd**](https://github.com/Microsoft/macos-cookbook/blob/master/libraries/security_cmd.rb) library.
 
 Syntax
 ------
@@ -16,6 +16,7 @@ certificate 'cert name' do
   certfile                      String # certificate in .p12(PFX) or .cer(SSl certificate file) format
   cert_passwd                   String # password for PFX format certificate file
   keychain                      String # keychain to install certificate to
+  kc_passwd                     String # keychain password
   apps                          Array  # list of apps that may access the imported key
 end
 ```
@@ -48,6 +49,7 @@ certificate 'cert name' do
   certfile '/User/edward/Documents/cert.p12'
   cert_passwd 'teach'
   keychain '/User/edward/Library/Keychains/florida.keychain'
+  kc_passwd 'test'
 end
 ```
 

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -5,6 +5,7 @@ provides :certificate
 property :certfile, String
 property :cert_password, String
 property :keychain, String
+property :kc_passwd, String
 property :apps, Array
 
 action_class do
@@ -17,7 +18,7 @@ action :install do
   cert = SecurityCommand.new(new_resource.certfile, keychain)
 
   execute 'unlock keychain' do
-    command Array(cert.unlock_keychain(node['macos']['admin_password']))
+    command Array(cert.unlock_keychain(new_resource.kc_passwd))
   end
 
   execute 'install-certificate' do

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -1,21 +1,16 @@
 unified_mode true
 
 provides :certificate
+default_action :install
 
 property :certfile, String
 property :cert_password, String, sensitive: true
-property :keychain, String
+property :keychain, String, required: true
 property :kc_passwd, String, sensitive: true
 property :apps, Array
 
-action_class do
-  def keychain
-    new_resource.property_is_set?(:keychain) ? new_resource.keychain : ''
-  end
-end
-
 action :install do
-  cert = SecurityCommand.new(new_resource.certfile, keychain)
+  cert = SecurityCommand.new(new_resource.certfile, new_resource.keychain)
 
   execute 'unlock keychain' do
     password = new_resource.property_is_set?(:kc_passwd) ? new_resource.kc_passwd : node['macos']['admin_password']

--- a/test/cookbooks/macos_test/recipes/certificate.rb
+++ b/test/cookbooks/macos_test/recipes/certificate.rb
@@ -27,6 +27,7 @@ end
 certificate 'install a .cer format certificate file' do
   certfile foobar_cer_path
   keychain '/Users/vagrant/Library/Keychains/login.keychain'
+  kc_passwd node['macos']['admin_password']
   apps ['/Applications/Numbers.app']
   action :install
 end
@@ -35,6 +36,7 @@ certificate 'install a PFX format certificate file' do
   certfile '/Users/vagrant/Test.p12'
   cert_password 'test'
   keychain '/Users/vagrant/Library/Keychains/test.keychain'
+  kc_passwd node['macos']['admin_password']
   apps ['/Applications/Safari.app']
   action :install
 end

--- a/test/cookbooks/macos_test/recipes/certificate.rb
+++ b/test/cookbooks/macos_test/recipes/certificate.rb
@@ -36,7 +36,7 @@ certificate 'install a PFX format certificate file' do
   certfile '/Users/vagrant/Test.p12'
   cert_password 'test'
   keychain '/Users/vagrant/Library/Keychains/test.keychain'
-  kc_passwd node['macos']['admin_password']
+  kc_passwd 'test'
   apps ['/Applications/Safari.app']
   action :install
 end


### PR DESCRIPTION
---
name: Pull Request
about: File a pull request to help us improve
title: "[PR]"
labels: ''
assignees: ''

---

## Describe the Pull Request  
When using the certificate resource install a certificate to a locked keychain, the password to unlock is only settable via the `node['macos']['admin_password']` attribute. 

This means users of the certificate resource will have to re-declare this above any calls to the resource unless it's in kitchen. 

This PR, remove that logic and instead introduces a kc_passwd property similar to the keychain resource to allow users to input this password. 

## Justification  
Not really a bug but a QOL improvement.  