### PR TITLE
Add new property for setting user

### DIFF
--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -8,6 +8,7 @@ property :cert_password, String, sensitive: true
 property :keychain, String, required: true
 property :kc_passwd, String, required: true, sensitive: true
 property :apps, Array, default: []
+property :user, String
 property :sensitive, [true, false], default: false
 
 action :install do
@@ -15,6 +16,7 @@ action :install do
 
   execute 'unlock keychain' do
     command Array(cert.unlock_keychain(new_resource.kc_passwd))
+    user new_resource.user
     sensitive new_resource.sensitive
   end
 
@@ -23,6 +25,7 @@ action :install do
 
   execute 'install-certificate' do
     command Array(cert.install_certificate(new_resource.cert_password, new_resource.apps))
+    user new_resource.user
     sensitive new_resource.sensitive
     not_if { find_cert_output.include? cert_shasum }
   end

--- a/resources/keychain.rb
+++ b/resources/keychain.rb
@@ -5,6 +5,7 @@ default_action :create
 
 property :kc_file, String
 property :kc_passwd, String, sensitive: true
+property :user, String
 property :sensitive, [true, false], default: false
 
 action_class do
@@ -18,6 +19,7 @@ action :create do
 
   execute 'create a keychain' do
     command Array(keyc.create_keychain(new_resource.kc_passwd))
+    user new_resource.user
     sensitive new_resource.sensitive
     not_if { ::File.exist? keychain + '-db' }
   end
@@ -27,6 +29,7 @@ action :delete do
   keyc = SecurityCommand.new('', keychain)
   execute 'delete selected keychain' do
     command Array(keyc.delete_keychain)
+    user new_resource.user
     sensitive new_resource.sensitive
     only_if { ::File.exist?(keychain) }
   end
@@ -36,6 +39,7 @@ action :lock do
   keyc = SecurityCommand.new('', keychain)
   execute 'lock selected keychain' do
     command Array(keyc.lock_keychain)
+    user new_resource.user
     sensitive new_resource.sensitive
     only_if { ::File.exist?(keychain) }
   end
@@ -45,6 +49,7 @@ action :unlock do
   keyc = SecurityCommand.new('', keychain)
   execute 'unlock selected keychain' do
     command Array(keyc.unlock_keychain(new_resource.kc_passwd))
+    user new_resource.user
     sensitive new_resource.sensitive
     only_if { ::File.exist?(keychain) }
   end


### PR DESCRIPTION
## Describe the Pull Request  
Add a new property to pass `user` for certificates and keychain resources

## Justification  
Allows for the keychain and certs to be owned by a specific user. In our use-case, if not provided then the keychain is owned by `root` which makes it hard for the separate build user to unlock keychains during `xcodebuild` or `codesign`

This one's a bit more complex than the last couple minor tweaks ... I've tested it with and without the property when calling the resource: if provided sets it to the owner, else owned by `root`.
Not sure how (or if) there will conflict with `node['macos']['admin_user']` depending on desired use case.