### PR TITLE
deprecate `plist` resource in favor of core `plist` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changed
 
+- Deprecated `plist` resource in favor of the `plist` resource included with Chef Client >=16.
 - Unified `macos_user` test suites.
 - Updated `macos_user` resource to use not utilize default attributes for authorization.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # macOS Cookbook
 
-[![Build Status](https://dev.azure.com/office/OE/_apis/build/status/Microsoft.macos-cookbook?branchName=master)](https://dev.azure.com/office/OE/_build/latest?definitionId=5072&branchName=master)
+[![Build Status](https://dev.azure.com/office/OE/_apis/build/status/microsoft.macos-cookbook?repoName=microsoft%2Fmacos-cookbook&branchName=master)](https://dev.azure.com/office/OE/_build/latest?definitionId=17314&repoName=microsoft%2Fmacos-cookbook&branchName=master)
 
 Chef resources and recipes for managing and provisioning macOS.
 

--- a/README.md
+++ b/README.md
@@ -4,33 +4,31 @@
 
 Chef resources and recipes for managing and provisioning macOS.
 
-- [Chef Requirements](#chef-requirements)
-- [Supported OS Versions](#supported-os-versions)
-- [Attributes](#attributes)
-- [Recipes](#recipes)
-- [Data Bags](#data-bags)
-- [Resources](#resources)
+- [Chef Requirements](#officially-supported-chef-versions)
+- [macOS Requirements](#officially-supported-os-versions)
+- [Included Resources](#resources)
 
 ## Officially Supported Chef Versions
 
 - Chef 16
 - Chef 17
 
-## Supported OS Versions
+## Officially Supported OS Versions
 
-- macOS High Sierra 10.13
-- macOS Mojave 10.14
-- macOS Catalina 10.15
-- macOS Big Sur 11.0
+- macOS 10.14 Mojave
+- macOS 10.15 Catalina
+- macOS 11 Big Sur
+- macos 12 Monterey
 
 ## Resources
+**The plist resource is deprecated and will be removed in the next major release of macos-cookbook. Please use the plist resource included with Chef Client >=16.**
 
+- ~~[`plist`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_plist.md)~~
 - [`automatic_software_updates`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_automatic_software_updates.md)
 - [`certificate`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_certificate.md)
 - [`command_line_tools`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_command_line_tools.md)
 - [`keychain`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_keychain.md)
 - [`macos_user`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_macos_user.md)
-- [`plist`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_plist.md)
 - [`remote_management`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_remote_management.md)
 - [`spotlight`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_spotlight.md)
 - [`xcode`](https://github.com/Microsoft/macos-cookbook/blob/master/documentation/resource_xcode.md)

--- a/libraries/plist.rb
+++ b/libraries/plist.rb
@@ -136,18 +136,14 @@ module MacOS
   end
 end
 
-module Chef::Deprecated
+class Chef::Deprecated
   class Base
     BASE_URL = 'https://github.com/microsoft/macos-cookbook/blob/master/README.md'.freeze
   end
 
   class Plistresource < Base
-    def to_s
-      'The plist resource is deprecated and will be removed in the next major release of macos-cookbook. Please use the plist resource included with Chef Client >=16.'
-    end
   end
 end
 
-Chef::Deprecated.include Chef::Deprecated
 Chef::Resource.include MacOS::PlistHelpers
 Chef::DSL::Recipe.include MacOS::PlistHelpers

--- a/libraries/plist.rb
+++ b/libraries/plist.rb
@@ -136,19 +136,18 @@ module MacOS
   end
 end
 
-class MacOS::Deprecated
+module Chef::Deprecated
   class Base
     BASE_URL = 'https://github.com/microsoft/macos-cookbook/blob/master/README.md'.freeze
   end
 
-  class PlistResource < Base
-    target nil
-
+  class Plistresource < Base
     def to_s
       'The plist resource is deprecated and will be removed in the next major release of macos-cookbook. Please use the plist resource included with Chef Client >=16.'
     end
   end
+end
 
-Chef::Deprecated.include MacOS::Deprecated
+Chef::Deprecated.include Chef::Deprecated
 Chef::Resource.include MacOS::PlistHelpers
 Chef::DSL::Recipe.include MacOS::PlistHelpers

--- a/libraries/plist.rb
+++ b/libraries/plist.rb
@@ -135,5 +135,20 @@ module MacOS
     end
   end
 end
+
+class MacOS::Deprecated
+  class Base
+    BASE_URL = 'https://github.com/microsoft/macos-cookbook/blob/master/README.md'.freeze
+  end
+
+  class PlistResource < Base
+    target nil
+
+    def to_s
+      'The plist resource is deprecated and will be removed in the next major release of macos-cookbook. Please use the plist resource included with Chef Client >=16.'
+    end
+  end
+
+Chef::Deprecated.include MacOS::Deprecated
 Chef::Resource.include MacOS::PlistHelpers
 Chef::DSL::Recipe.include MacOS::PlistHelpers

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -28,6 +28,8 @@ load_current_value do |desired|
 end
 
 action :set do
+  Chef.deprecated(:plistresource, 'test message')
+
   converge_if_changed :path do
     converge_by "create new plist: '#{new_resource.path}'" do
       file new_resource.path do

--- a/resources/plist.rb
+++ b/resources/plist.rb
@@ -28,7 +28,10 @@ load_current_value do |desired|
 end
 
 action :set do
-  Chef.deprecated(:plistresource, 'test message')
+  deprecation_warning = 'The plist resource is deprecated and will be removed in the next major release of macos-cookbook. Please use the plist resource included with Chef Client >=16'
+
+  Chef.deprecated :plistresource, deprecation_warning
+  Chef::Log.warn deprecation_warning
 
   converge_if_changed :path do
     converge_by "create new plist: '#{new_resource.path}'" do

--- a/test/cookbooks/macos_test/recipes/plist.rb
+++ b/test/cookbooks/macos_test/recipes/plist.rb
@@ -1,0 +1,3 @@
+plist 'test' do
+  path '/Users/vagrant/test.plist'
+end

--- a/test/cookbooks/macos_test/recipes/plist.rb
+++ b/test/cookbooks/macos_test/recipes/plist.rb
@@ -1,3 +1,0 @@
-plist 'test' do
-  path '/Users/vagrant/test.plist'
-end


### PR DESCRIPTION
##This PR:

- Deprecates `plist` resource in favor of the `plist` resource included with Chef Client >=16.