### PR TITLE
Fix autologin on 11.6.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Extracted authentication with Apple via `xcode` resource away `xcode` object instantiation, resolving [Bug #234](https://github.com/microsoft/macos-cookbook/issues/234).
 - Enabled `macos_user` resource to parse `sysadminctl` stderr, resolving [Bug 197](https://github.com/microsoft/macos-cookbook/issues/197).
 - Reversed order of arguments for certificate installation, resolving [Bug 244](https://github.com/microsoft/macos-cookbook/issues/244).
+- Fixed `macos_user` resource `autologin` functionality to dismiss Welcome "buddy" screens after updating to 11.6.5 via `softwareupdate`.
 
 ### Added
 

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -38,7 +38,11 @@ action_class do
     { 'DidSeeCloudSetup' => true,
       'DidSeeSiriSetup' => true,
       'DidSeePrivacy' => true,
+      'DidSeeAccessibility' => true,
+      'DidSeeAppearance' => true,
       'LastSeenCloudProductVersion' => node['platform_version'],
+      'LastPreLoginTasksPerformedVersion' => node['platform_version'],
+      'LastPreLoginTasksPerformedBuild' => node['platform_build'],
       'LastSeenBuddyBuildVersion' => node['platform_build'],
     }
   end


### PR DESCRIPTION
Fixed `macos_user` resource `autologin` functionality to dismiss Welcome "buddy" screens after updating to 11.6.5 via `softwareupdate`.