### PR TITLE
align certificate and keychain property names, refactor SecurityCommand module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,26 @@
 ### Added
 
 - Added `apple_id` property to `xcode` resource to remove dependency on attributes or data bags for authentication.
-- New certificate resource property: `kc_passwd` which allows setting of keychain password.
+- New `certificate` resource property: `keychain_password` which allows specification of the keychain password.
+- New `keychain` resource property: `user` which allows specification of an executing user.
 - New test suites and recipe change to account for `.cer` files.
 - Check for certificate existence within the keychain before installing a new one to ensure idempotency.
-- Made certificate password properties sensitive.
-- Updated certificate resource documentation.
 - Support for Mac Studio in `FormFactor` class. 
 - Secure token support for `macos_user` resource via new properties `secure_token` and `existing_token_auth`.
 - New unit and integration tests for `macos_user` resource.
 - Updated our README to include Monterey support. 
-- Added the documentation directory to chefignore as we don't need to upload all our docs to the Chef Infra Server. 
+- Added the documentation directory to chefignore as we don't need to upload all our docs to Chef Infra Servers. 
 
 ### Changed
 
+- Changed `certificate` property names to be more clear within resource scope and consistent with `keychain` resource:
+  - `certfile` is now `path`
+  - `cert_passwd` is now `password`
+  - `keychain` is now `keychain_path`
+- Changed `keychain` property names to be more clear within resource scope and consistent with `certificate` resource:
+  - `kc_file` is now `path`
+  - `kc_passwd` is now `password`
+- Made certificate password properties sensitive.
 - Deprecated `plist` resource in favor of the `plist` resource included with Chef Client >=16.
 - Unified `macos_user` test suites.
 - Updated `macos_user` resource to use not utilize default attributes for authorization.

--- a/documentation/resource_certificate.md
+++ b/documentation/resource_certificate.md
@@ -13,12 +13,12 @@ is:
 
 ```ruby
 certificate 'cert name' do
-  path                      String # certificate in .p12(PFX) or .cer(SSl certificate file) format. defaults to 'name' if not specified
+  path                     String # certificate in .p12(PFX) or .cer(SSl certificate file) format. defaults to 'name' if not specified
   password                 String # password for PFX format certificate file
-  keychain_path                      String # keychain to install certificate to
-  keychain_password                     String # keychain password
-  apps                          Array  # list of apps that may access the imported key
-  sensitive                     Boolean # run execute resource with sensitive
+  keychain_path            String # keychain to install certificate to
+  keychain_password        String # keychain password
+  apps                     Array  # list of apps that may access the imported key
+  sensitive                Boolean # run execute resource with sensitive
 end
 ```
 

--- a/documentation/resource_certificate.md
+++ b/documentation/resource_certificate.md
@@ -13,10 +13,10 @@ is:
 
 ```ruby
 certificate 'cert name' do
-  certfile                      String # certificate in .p12(PFX) or .cer(SSl certificate file) format
-  cert_password                 String # password for PFX format certificate file
-  keychain                      String # keychain to install certificate to
-  kc_passwd                     String # keychain password
+  path                      String # certificate in .p12(PFX) or .cer(SSl certificate file) format. defaults to 'name' if not specified
+  password                 String # password for PFX format certificate file
+  keychain_path                      String # keychain to install certificate to
+  keychain_password                     String # keychain password
   apps                          Array  # list of apps that may access the imported key
   sensitive                     Boolean # run execute resource with sensitive
 end
@@ -28,7 +28,7 @@ Actions
 `:install`
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Install the certificate as specified by
-the `certfile` property. This is the only, and default, action.
+the `path` property. This is the only, and default, action.
 
 
 Examples
@@ -38,8 +38,8 @@ Examples
 
 ```ruby
 certificate 'cert name' do
-  certfile '/User/edward/Documents/cert.p12'
-  cert_password 'teach'
+  path '/User/edward/Documents/cert.p12'
+  password 'teach'
 end
 ```
 
@@ -47,10 +47,10 @@ end
 
 ```ruby
 certificate 'cert name' do
-  certfile '/User/edward/Documents/cert.p12'
-  cert_password 'teach'
-  keychain '/User/edward/Library/Keychains/florida.keychain'
-  kc_passwd 'test'
+  path '/User/edward/Documents/cert.p12'
+  password 'teach'
+  keychain_path '/User/edward/Library/Keychains/florida.keychain'
+  keychain_password 'test'
 end
 ```
 
@@ -58,7 +58,7 @@ end
 
 ```ruby
 certificate 'cert name' do
-  certfile '/User/edward/Documents/cert.p12'
+  path '/User/edward/Documents/cert.p12'
 end
 ```
 
@@ -66,17 +66,17 @@ end
 
 ```ruby
 certificate 'cert name' do
-  certfile '/User/edward/Documents/cert.p12'
-  keychain '/User/edward/Library/Keychains/florida.keychain'
-  kc_passwd 'test'
+  path '/User/edward/Documents/cert.p12'
+  keychain_path '/User/edward/Library/Keychains/florida.keychain'
+  keychain_password 'test'
 end
 ```
 
 **Install PFX format certificate to default keychain, accessible by certain app**
 ```ruby
 certificate 'cert name' do
-  certfile '/User/edward/Documents/cert.p12'
-  cert_password 'teach'
+  path '/User/edward/Documents/cert.p12'
+  password 'teach'
   apps ['/Applications/Maps.app', '/Applications/Time Machine.app']
 end
 ```

--- a/documentation/resource_keychain.md
+++ b/documentation/resource_keychain.md
@@ -13,8 +13,8 @@ is:
 
 ```ruby
 keychain 'keychain name' do
-  kc_file                       String # path to selected keychain
-  kc_passwd                     String # password for selected keychain
+  path                       String # path to selected keychain, defaults to 'name' if not specified
+  password                     String # password for selected keychain
   sensitive                     Boolean # run execute resource with sensitive
 end
 ```
@@ -25,23 +25,23 @@ Actions
 `:create`
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Create a keychain as specified by
-the `kc_file` property. This is the default action.
+the `path` property. This is the default action.
 
 `:delete`
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Delete a keychain as specified by
-the `kc_file` property.
+the `path` property.
 
 `:lock`
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Lock a keychain as specified by
-the `kc_file` property. If no keychain is specified, the default keychain
+the `path` property. If no keychain is specified, the default keychain
 will be locked instead.
 
 `:unlock`
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Using the `kc_passwd` property, unlock a
-keychain as specified by the `kc_file` property. If no keychain is specified,
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Using the `password` property, unlock a
+keychain as specified by the `path` property. If no keychain is specified,
 the default keychain will be unlocked instead.
 
 
@@ -53,8 +53,8 @@ Examples
 
 ```ruby
 keychain 'test' do
-  kc_file '/User/edward/Library/Keychains/test.keychain'
-  kc_passwd 'test'
+  path '/User/edward/Library/Keychains/test.keychain'
+  password 'test'
   action :create
 end
 ```
@@ -63,7 +63,7 @@ end
 
 ```ruby
 keychain 'test' do
-  kc_file '/User/edward/Library/Keychains/test.keychain'
+  path '/User/edward/Library/Keychains/test.keychain'
   action :delete
 end
 ```
@@ -72,8 +72,8 @@ end
 
 ```ruby
 keychain 'login' do
-  kc_file '/User/edward/Library/Keychains/login.keychain'
-  kc_passwd 'login_password'
+  path '/User/edward/Library/Keychains/login.keychain'
+  password 'login_password'
   action :create
 end
 ```
@@ -82,7 +82,7 @@ end
 
 ```ruby
 keychain 'test' do
-  kc_file '/User/edward/Library/Keychains/test.keychain'
+  path '/User/edward/Library/Keychains/test.keychain'
   action :lock
 end
 ```
@@ -91,8 +91,8 @@ end
 
 ```ruby
 keychain 'test' do
-  kc_file '/User/edward/Library/Keychains/test.keychain'
-  kc_passwd 'test'
+  path '/User/edward/Library/Keychains/test.keychain'
+  password 'test'
   action :unlock
 end
 ```

--- a/documentation/resource_keychain.md
+++ b/documentation/resource_keychain.md
@@ -13,9 +13,9 @@ is:
 
 ```ruby
 keychain 'keychain name' do
-  path                       String # path to selected keychain, defaults to 'name' if not specified
-  password                     String # password for selected keychain
-  sensitive                     Boolean # run execute resource with sensitive
+  path                      String # path to selected keychain, defaults to 'name' if not specified
+  password                  String # password for selected keychain
+  sensitive                 Boolean # run execute resource with sensitive
 end
 ```
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -41,7 +41,7 @@ platforms:
 - name: monterey-chef17
   driver:
     box: microsoft/macos-monterey
-    box_version: 12.3
+    box_version: 12.3.1
   provisioner:
     product_version: 17
 

--- a/libraries/security_cmd.rb
+++ b/libraries/security_cmd.rb
@@ -25,15 +25,15 @@ module MacOS
     end
 
     def lock_keychain
-      @keychain.empty? ? [@security_cmd, 'lock-keychain'] : [@security_cmd, 'lock-keychain', @keychain]
+      @keychain.nil? ? [@security_cmd, 'lock-keychain'] : [@security_cmd, 'lock-keychain', @keychain]
     end
 
-    def unlock_keychain(kc_passwd)
-      @keychain.empty? ? [@security_cmd, 'unlock-keychain', '-p', kc_passwd] : [@security_cmd, 'unlock-keychain', '-p', kc_passwd, @keychain]
+    def unlock_keychain(password)
+      @keychain.nil? ? [@security_cmd, 'unlock-keychain', '-p', password] : [@security_cmd, 'unlock-keychain', '-p', password, @keychain]
     end
 
     def add_certificates
-      @keychain.empty? ? [@security_cmd, 'add-certificates', @cert] : [@security_cmd, 'add-certificates', '-k', @keychain, @cert]
+      @keychain.nil? ? [@security_cmd, 'add-certificates', @cert] : [@security_cmd, 'add-certificates', '-k', @keychain, @cert]
     end
 
     def import(cert_passwd, apps)
@@ -43,7 +43,12 @@ module MacOS
         app_array.push('-T')
         app_array.push(app)
       end
-      @keychain == '' ? [@security_cmd, 'import', @cert, '-P', cert_passwd, *app_array] : [@security_cmd, 'import', @cert, '-P', cert_passwd, '-k', @keychain, *app_array]
+
+      if @keychain.nil?
+        [@security_cmd, 'import', @cert, '-P', cert_passwd, *app_array]
+      else
+        [@security_cmd, 'import', @cert, '-P', cert_passwd, '-k', @keychain, *app_array]
+      end
     end
 
     def install_certificate(cert_passwd, apps)

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -11,7 +11,7 @@ property :apps, Array, default: []
 property :user, String
 
 action :install do
-  cert = SecurityCommand.new(**{ cert: new_resource.path, keychain: new_resource.keychain_path})
+  cert = SecurityCommand.new(**{ cert: new_resource.path, keychain: new_resource.keychain_path })
 
   execute 'unlock keychain' do
     command Array(cert.unlock_keychain(new_resource.keychain_password))

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -3,27 +3,27 @@ unified_mode true
 provides :certificate
 default_action :install
 
-property :certfile, String
-property :cert_password, String, sensitive: true
-property :keychain, String, required: true
-property :kc_passwd, String, required: true, sensitive: true
+property :path, String, name_property: true
+property :password, String, sensitive: true
+property :keychain_path, String
+property :keychain_password, String, sensitive: true
 property :apps, Array, default: []
 property :user, String
 
 action :install do
-  cert = SecurityCommand.new(new_resource.certfile, new_resource.keychain)
+  cert = SecurityCommand.new(new_resource.path, new_resource.keychain_path)
 
   execute 'unlock keychain' do
-    command Array(cert.unlock_keychain(new_resource.kc_passwd))
+    command Array(cert.unlock_keychain(new_resource.keychain_password))
     user new_resource.user
     sensitive true
   end
 
-  cert_shasum = shell_out("shasum #{new_resource.certfile}").stdout.upcase.gsub(/\s.+/, '')
-  find_cert_output = shell_out("/usr/bin/security find-certificate -a -Z #{new_resource.keychain}").stdout
+  cert_shasum = shell_out("shasum #{new_resource.path}").stdout.upcase.gsub(/\s.+/, '')
+  find_cert_output = shell_out("/usr/bin/security find-certificate -a -Z #{new_resource.keychain_path}").stdout
 
   execute 'install-certificate' do
-    command Array(cert.install_certificate(new_resource.cert_password, new_resource.apps))
+    command Array(cert.install_certificate(new_resource.password, new_resource.apps))
     user new_resource.user
     sensitive true
     not_if { find_cert_output.include? cert_shasum }

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -11,7 +11,7 @@ property :apps, Array, default: []
 property :user, String
 
 action :install do
-  cert = SecurityCommand.new(new_resource.path, new_resource.keychain_path)
+  cert = SecurityCommand.new(**{ cert: new_resource.path, keychain: new_resource.keychain_path})
 
   execute 'unlock keychain' do
     command Array(cert.unlock_keychain(new_resource.keychain_password))

--- a/resources/keychain.rb
+++ b/resources/keychain.rb
@@ -3,53 +3,48 @@ unified_mode true
 provides :keychain
 default_action :create
 
-property :kc_file, String
-property :kc_passwd, String, sensitive: true
+property :path, String, name_property: true
+property :password, String, sensitive: true
 property :user, String
 
 action_class do
-  def keychain
-    new_resource.property_is_set?(:kc_file) ? new_resource.kc_file : nil
+  def security
+    SecurityCommand.new('', new_resource.path)
   end
 end
 
 action :create do
-  keyc = SecurityCommand.new('', keychain)
-
   execute 'create a keychain' do
-    command Array(keyc.create_keychain(new_resource.kc_passwd))
+    command Array(security.create_keychain(new_resource.password))
     user new_resource.user
     sensitive true
-    not_if { ::File.exist? keychain + '-db' }
+    not_if { ::File.exist? new_resource.path + '-db' }
   end
 end
 
 action :delete do
-  keyc = SecurityCommand.new('', keychain)
   execute 'delete selected keychain' do
-    command Array(keyc.delete_keychain)
+    command Array(security.delete_keychain)
     user new_resource.user
     sensitive true
-    only_if { ::File.exist?(keychain) }
+    only_if { ::File.exist?(new_resource.path) }
   end
 end
 
 action :lock do
-  keyc = SecurityCommand.new('', keychain)
   execute 'lock selected keychain' do
-    command Array(keyc.lock_keychain)
+    command Array(security.lock_keychain)
     user new_resource.user
     sensitive true
-    only_if { ::File.exist?(keychain) }
+    only_if { ::File.exist?(new_resource.path) }
   end
 end
 
 action :unlock do
-  keyc = SecurityCommand.new('', keychain)
   execute 'unlock selected keychain' do
-    command Array(keyc.unlock_keychain(new_resource.kc_passwd))
+    command Array(security.unlock_keychain(new_resource.password))
     user new_resource.user
     sensitive true
-    only_if { ::File.exist?(keychain) }
+    only_if { ::File.exist?(new_resource.path) }
   end
 end

--- a/resources/keychain.rb
+++ b/resources/keychain.rb
@@ -9,7 +9,7 @@ property :user, String
 
 action_class do
   def security
-    SecurityCommand.new('', new_resource.path)
+    SecurityCommand.new(**{ keychain: new_resource.path})
   end
 end
 

--- a/resources/keychain.rb
+++ b/resources/keychain.rb
@@ -9,7 +9,7 @@ property :user, String
 
 action_class do
   def security
-    SecurityCommand.new(**{ keychain: new_resource.path})
+    SecurityCommand.new(**{ keychain: new_resource.path })
   end
 end
 

--- a/spec/unit/libraries/security_cmd_spec.rb
+++ b/spec/unit/libraries/security_cmd_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 include MacOS
 
 describe MacOS::SecurityCommand, 'certificate creation commands' do
-  let(:p12_cert) { MacOS::SecurityCommand.new('/Users/vagrant/Test.p12', '') }
-  let(:p12_cert_kc) { MacOS::SecurityCommand.new('/Users/vagrant/Test.p12', 'test.keychain') }
-  let(:cer_cert) { MacOS::SecurityCommand.new('/Users/vagrant/Test.cer', '') }
-  let(:cer_cert_kc) { MacOS::SecurityCommand.new('/Users/vagrant/Test.cer', 'test.keychain') }
+  let(:p12_cert) { MacOS::SecurityCommand.new(**{ cert: '/Users/vagrant/Test.p12' }) }
+  let(:p12_cert_kc) { MacOS::SecurityCommand.new(**{ cert: '/Users/vagrant/Test.p12', keychain: 'test.keychain' }) }
+  let(:cer_cert) { MacOS::SecurityCommand.new(**{ cert: '/Users/vagrant/Test.cer' }) }
+  let(:cer_cert_kc) { MacOS::SecurityCommand.new(**{ cert: '/Users/vagrant/Test.cer', keychain: 'test.keychain' }) }
 
   context 'when SecurityCommand object is instantiated' do
     it 'security should use /usr/bin/security' do
@@ -21,7 +21,7 @@ describe MacOS::SecurityCommand, 'certificate creation commands' do
 
   context 'when SecurityCommand object is instantiated' do
     it 'returns a keychain matching the specified keychain' do
-      expect(p12_cert.keychain).to eq ''
+      expect(p12_cert.keychain).to eq nil
     end
   end
 
@@ -33,25 +33,32 @@ describe MacOS::SecurityCommand, 'certificate creation commands' do
 
   context 'unlocking a keychain' do
     it 'unlocks a specific keychain matching the specified command' do
-      expect(p12_cert_kc.unlock_keychain('password')).to eq ['/usr/bin/security', 'unlock-keychain', '-p', 'password', 'test.keychain']
+      expect(p12_cert_kc.unlock_keychain('password')).to eq ['/usr/bin/security', 'unlock-keychain', '-p', 'password',
+                                                             'test.keychain']
     end
   end
 
   context 'importing a certificate (.p12)' do
     it 'imports a specified .p12 certificate file' do
-      expect(p12_cert.import('password', [])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P', 'password']
+      expect(p12_cert.import('password',
+                             [])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P', 'password']
     end
   end
 
   context 'importing a certificate (.p12)' do
     it 'imports a specified .p12 certificate file to a specified keychain' do
-      expect(p12_cert_kc.import('password', [])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P', 'password', '-k', 'test.keychain']
+      expect(p12_cert_kc.import('password',
+                                [])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P', 'password',
+                                            '-k', 'test.keychain']
     end
   end
 
   context 'importing a certificate (.p12) accessible by Mail and App Store ' do
     it 'imports a specified .p12 certificate file to a specified keychain' do
-      expect(p12_cert_kc.import('password', ['/Applications/Mail.app', '/Applications/App Store.app'])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P', 'password', '-k', 'test.keychain', '-T', '/Applications/Mail.app', '-T', '/Applications/App Store.app']
+      expect(p12_cert_kc.import('password',
+                                ['/Applications/Mail.app',
+                                 '/Applications/App Store.app'])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P', 'password',
+                                                                         '-k', 'test.keychain', '-T', '/Applications/Mail.app', '-T', '/Applications/App Store.app']
     end
   end
 
@@ -63,42 +70,50 @@ describe MacOS::SecurityCommand, 'certificate creation commands' do
 
   context 'adding a certificate (.cer) to a certain keychain' do
     it 'adds a specified .cer certificate file' do
-      expect(cer_cert_kc.add_certificates).to eq ['/usr/bin/security', 'add-certificates', '-k', 'test.keychain', '/Users/vagrant/Test.cer']
+      expect(cer_cert_kc.add_certificates).to eq ['/usr/bin/security', 'add-certificates', '-k', 'test.keychain',
+                                                  '/Users/vagrant/Test.cer']
     end
   end
 
   context 'installing a certificate (.p12)' do
     it 'installs a specified .p12 certificate file' do
-      expect(p12_cert.install_certificate('password', [])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P', 'password']
+      expect(p12_cert.install_certificate('password',
+                                          [])).to eq ['/usr/bin/security', 'import', '/Users/vagrant/Test.p12', '-P',
+                                                      'password']
     end
   end
 
   context 'installing a certificate (.cer)' do
     it 'adds a specified .cer certificate file' do
-      expect(cer_cert.install_certificate('password', [])).to eq ['/usr/bin/security', 'add-certificates', '/Users/vagrant/Test.cer']
+      expect(cer_cert.install_certificate('password',
+                                          [])).to eq ['/usr/bin/security', 'add-certificates',
+                                                      '/Users/vagrant/Test.cer']
     end
   end
 end
 
 describe MacOS::SecurityCommand, 'keychain creation commands' do
-  let(:test_kc) { MacOS::SecurityCommand.new('', '/Users/vagrant/Library/Keychains/test.keychain') }
-  let(:test_kc_default) { MacOS::SecurityCommand.new('', '') }
+  let(:test_kc) { MacOS::SecurityCommand.new(**{ keychain: '/Users/vagrant/Library/Keychains/test.keychain' }) }
+  let(:test_kc_default) { MacOS::SecurityCommand.new }
 
   context 'creating a new keychain' do
     it 'creates the appropriate .keychain file' do
-      expect(test_kc.create_keychain('password')).to eq ['/usr/bin/security', 'create-keychain', '-p', 'password', '/Users/vagrant/Library/Keychains/test.keychain']
+      expect(test_kc.create_keychain('password')).to eq ['/usr/bin/security', 'create-keychain', '-p', 'password',
+                                                         '/Users/vagrant/Library/Keychains/test.keychain']
     end
   end
 
   context 'deleting a keychain' do
     it 'deletes the appropriate .keychain file' do
-      expect(test_kc.delete_keychain).to eq ['/usr/bin/security', 'delete-keychain', '/Users/vagrant/Library/Keychains/test.keychain']
+      expect(test_kc.delete_keychain).to eq ['/usr/bin/security', 'delete-keychain',
+                                             '/Users/vagrant/Library/Keychains/test.keychain']
     end
   end
 
   context 'locking a specified keychain' do
     it 'locks a specified keychain' do
-      expect(test_kc.lock_keychain).to eq ['/usr/bin/security', 'lock-keychain', '/Users/vagrant/Library/Keychains/test.keychain']
+      expect(test_kc.lock_keychain).to eq ['/usr/bin/security', 'lock-keychain',
+                                           '/Users/vagrant/Library/Keychains/test.keychain']
     end
   end
 
@@ -110,13 +125,15 @@ describe MacOS::SecurityCommand, 'keychain creation commands' do
 
   context 'unlocking a certain keychain' do
     it 'unlocks a specified keychain' do
-      expect(test_kc.unlock_keychain('password')).to eq ['/usr/bin/security', 'unlock-keychain', '-p', 'password', '/Users/vagrant/Library/Keychains/test.keychain']
+      expect(test_kc.unlock_keychain('password')).to eq ['/usr/bin/security', 'unlock-keychain', '-p', 'password',
+                                                         '/Users/vagrant/Library/Keychains/test.keychain']
     end
   end
 
   context 'unlocking default keychain' do
     it 'unlocks the default keychain' do
-      expect(test_kc_default.unlock_keychain('password')).to eq ['/usr/bin/security', 'unlock-keychain', '-p', 'password']
+      expect(test_kc_default.unlock_keychain('password')).to eq ['/usr/bin/security', 'unlock-keychain', '-p',
+                                                                 'password']
     end
   end
 end

--- a/test/cookbooks/macos_test/recipes/certificate.rb
+++ b/test/cookbooks/macos_test/recipes/certificate.rb
@@ -26,7 +26,7 @@ end
 
 certificate 'install a binary-formatted certificate' do
   path foobar_cer_path
-  keychain '/Users/vagrant/Library/Keychains/login.keychain'
+  keychain_path '/Users/vagrant/Library/Keychains/login.keychain'
   keychain_password 'vagrant'
   apps ['/Applications/Numbers.app']
   action :install
@@ -35,7 +35,7 @@ end
 certificate 'install a PFX format certificate file' do
   path '/Users/vagrant/Test.p12'
   password 'test'
-  keychain '/Users/vagrant/Library/Keychains/test.keychain'
+  keychain_path '/Users/vagrant/Library/Keychains/test.keychain'
   keychain_password 'test'
   apps ['/Applications/Safari.app']
   action :install

--- a/test/cookbooks/macos_test/recipes/certificate.rb
+++ b/test/cookbooks/macos_test/recipes/certificate.rb
@@ -19,12 +19,12 @@ openssl_x509_certificate foobar_pem_path do
   country 'US'
 end
 
-execute 'convert .pem certificate to .cer certificate' do
+execute 'convert certificate to binary format' do
   command ['/usr/bin/openssl', 'x509', '-inform', 'PEM', '-in', foobar_pem_path, '-outform', 'DER', '-out', foobar_cer_path]
   only_if { ::File.exist? foobar_pem_path }
 end
 
-certificate 'install a .cer format certificate file' do
+certificate 'install a binary-formatted certificate' do
   path foobar_cer_path
   keychain '/Users/vagrant/Library/Keychains/login.keychain'
   keychain_password 'vagrant'

--- a/test/cookbooks/macos_test/recipes/certificate.rb
+++ b/test/cookbooks/macos_test/recipes/certificate.rb
@@ -7,8 +7,8 @@ cookbook_file '/Users/vagrant/Test.p12' do
 end
 
 keychain 'test' do
-  kc_file '/Users/vagrant/Library/Keychains/test.keychain'
-  kc_passwd 'test'
+  path '/Users/vagrant/Library/Keychains/test.keychain'
+  password 'test'
   action :create
 end
 
@@ -25,18 +25,18 @@ execute 'convert .pem certificate to .cer certificate' do
 end
 
 certificate 'install a .cer format certificate file' do
-  certfile foobar_cer_path
+  path foobar_cer_path
   keychain '/Users/vagrant/Library/Keychains/login.keychain'
-  kc_passwd 'vagrant'
+  keychain_password 'vagrant'
   apps ['/Applications/Numbers.app']
   action :install
 end
 
 certificate 'install a PFX format certificate file' do
-  certfile '/Users/vagrant/Test.p12'
-  cert_password 'test'
+  path '/Users/vagrant/Test.p12'
+  password 'test'
   keychain '/Users/vagrant/Library/Keychains/test.keychain'
-  kc_passwd 'test'
+  keychain_password 'test'
   apps ['/Applications/Safari.app']
   action :install
 end

--- a/test/cookbooks/macos_test/recipes/keychain.rb
+++ b/test/cookbooks/macos_test/recipes/keychain.rb
@@ -1,12 +1,12 @@
 keychain 'create test keychain' do
-  kc_file '/Users/vagrant/Library/Keychains/test.keychain'
-  kc_passwd 'test'
+  path '/Users/vagrant/Library/Keychains/test.keychain'
+  password 'test'
   action :create
 end
 
 keychain 'unlock test keychain' do
-  kc_file '/Users/vagrant/Library/Keychains/test.keychain'
-  kc_passwd 'test'
+  path '/Users/vagrant/Library/Keychains/test.keychain'
+  password 'test'
   action :unlock
 end
 
@@ -20,7 +20,7 @@ end
 kcfile = '/Users/testuser/Library/Keychains/login.keychain'
 
 keychain 'create login keychain' do
-  kc_file kcfile
-  kc_passwd 'testuser'
+  path kcfile
+  password 'testuser'
   action :create
 end


### PR DESCRIPTION
- Changed `certificate` property names to be more clear within resource scope and consistent with `keychain` resource:
  - `certfile` is now `path`
  - `cert_passwd` is now `password`
  - `keychain` is now `keychain_path`
- Changed `keychain` property names to be more clear within resource scope and consistent with `certificate` resource:
  - `kc_file` is now `path`
  - `kc_passwd` is now `password`
 - Refactored SecurityCommand module to use named parameters instead of empty strings for optional instantiation arguments. 