### PR TITLE
Release/5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [5.0.1] - 2022-05-25
+
+### Fixed
+
+- Updated Setup Assistant keys for the `macos_user` resource to properly enable autologin after updating to 11.6.6
+- Updated required macOS minimums for the `xcode` resource to evaluate compatibility for the most recent Xcodes.
+
 ## [5.0.0] - 2022-03-31
 
 ### Fixed

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -63,7 +63,11 @@ module MacOS
       return '>= 10.13.6' if Gem::Dependency.new('Xcode', '>= 10.0', '<= 10.1').match?('Xcode', @semantic_version)
       return '>= 10.14.3' if Gem::Dependency.new('Xcode', '>= 10.2', '<= 10.3').match?('Xcode', @semantic_version)
       return '>= 10.14.4' if Gem::Dependency.new('Xcode', '>= 11.0', '<= 11.3.1').match?('Xcode', @semantic_version)
-      return '>= 10.15.2' if Gem::Dependency.new('Xcode', '>= 11.4').match?('Xcode', @semantic_version)
+      return '>= 10.15.2' if Gem::Dependency.new('Xcode', '>= 11.4', '<= 11.7').match?('Xcode', @semantic_version)
+      return '>= 10.15.4' if Gem::Dependency.new('Xcode', '>= 12.0', '<= 12.4').match?('Xcode', @semantic_version)
+      return '>= 11.0' if Gem::Dependency.new('Xcode', '>= 12.5', '<= 12.5.1').match?('Xcode', @semantic_version)
+      return '>= 11.3' if Gem::Dependency.new('Xcode', '>= 13.0', '<= 13.2.1').match?('Xcode', @semantic_version)
+      return '>= 12.0' if Gem::Dependency.new('Xcode', '>= 13.3').match?('Xcode', @semantic_version)
     end
 
     class Simulator

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '5.0.0'
+version '5.0.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -39,11 +39,13 @@ action_class do
       'DidSeeSiriSetup' => true,
       'DidSeePrivacy' => true,
       'DidSeeAccessibility' => true,
-      'DidSeeAppearance' => true,
+      'DidSeeAppearanceSetup' => true,
+      'DidSeeScreenTime' => true,
       'LastSeenCloudProductVersion' => node['platform_version'],
       'LastPreLoginTasksPerformedVersion' => node['platform_version'],
       'LastPreLoginTasksPerformedBuild' => node['platform_build'],
       'LastSeenBuddyBuildVersion' => node['platform_build'],
+      'LastSeenSiriProductVersion' => node['platform_version'],
     }
   end
 


### PR DESCRIPTION
# Changelog

## [5.0.1] - 2022-05-25

### Fixed

- Updated Setup Assistant keys for the `macos_user` resource to properly enable autologin after updating to 11.6.6
- Updated required macOS minimums for the `xcode` resource to evaluate compatibility for the most recent Xcodes.