### PR TITLE
Add more Xcode logging to better tell what Xcode version is being installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.0.2] - 2022-09-08
+
+### Added
+- Xcode resource logs the Xcode version to install computed from the provided version.
+- Xcode library supports calling the `version` property more than once by not changing the stored data type.
+
 ## [5.0.1] - 2022-05-25
 
 ### Fixed

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -130,7 +130,6 @@ suites:
     controls:
     - keychain-creation
     - login-keychain-creation
-    - default-keychain-creation
 
 - name: remote-access
   provisioner:

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -13,11 +13,11 @@ module MacOS
     end
 
     def determine_version
-      @version = if @download_url.empty?
-                   latest_xcode_revision(Xcode::Version.new(@semantic_version))
-                 else
-                   @semantic_version
-                 end
+      if @download_url.empty?
+        latest_xcode_revision(Xcode::Version.new(@semantic_version))
+      else
+        @semantic_version
+      end
     end
 
     def available_xcode_versions
@@ -41,7 +41,7 @@ module MacOS
 
     def current_path
       if installed_path.nil?
-        "/Applications/Xcode-#{@version.tr(' ', '.')}.app"
+        "/Applications/Xcode-#{@version.call.tr(' ', '.')}.app"
       else
         installed_path[@semantic_version]
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '5.0.1'
+version '5.0.2'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/spec/unit/libraries/xcode_spec.rb
+++ b/spec/unit/libraries/xcode_spec.rb
@@ -90,58 +90,49 @@ describe MacOS::Xcode do
     end
     it 'returns the name of the latest Xcode 12 beta when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('12.0', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '12 beta 4'
-      expect(xcode.version).to_not eq '12 beta'
-      expect(xcode.version).to_not eq '12 for macOS Universal Apps beta'
+      expect(xcode.version.call).to eq '12 beta 4'
+      expect(xcode.version.call).to_not eq '12 beta'
+      expect(xcode.version.call).to_not eq '12 for macOS Universal Apps beta'
     end
     it 'returns the name of the latest Xcode 11.6 beta when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('11.6', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '11.6 beta 2'
-      expect(xcode.version).to_not eq '11.6 beta'
-      expect(xcode.version).to_not eq '11.6 beta2'
+      expect(xcode.version.call).to eq '11.6 beta 2'
+      expect(xcode.version.call).to_not eq '11.6 beta'
+      expect(xcode.version.call).to_not eq '11.6 beta2'
     end
     it 'returns the name of Xcode 11.5 official when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('11.5', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '11.5'
-      expect(xcode.version).to_not eq '11.5 beta'
-      expect(xcode.version).to_not eq '11.5 Release Candidate'
+      expect(xcode.version.call).to eq '11.5'
+      expect(xcode.version.call).to_not eq '11.5 beta'
+      expect(xcode.version.call).to_not eq '11.5 Release Candidate'
     end
     it 'returns the name of Xcode 10 official when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('10.0', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '10'
-      expect(xcode.version).to_not eq '10 Release Candidate'
-      expect(xcode.version).to_not eq '10 beta 1'
+      expect(xcode.version.call).to eq '10'
+      expect(xcode.version.call).to_not eq '10 Release Candidate'
+      expect(xcode.version.call).to_not eq '10 beta 1'
     end
     it 'returns the name of Xcode 9.4.2 official when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '9.4.2'
-      expect(xcode.version).to_not eq '9.4.2 beta 2'
-      expect(xcode.version).to_not eq '9.4.2 beta 3'
+      expect(xcode.version.call).to eq '9.4.2'
+      expect(xcode.version.call).to_not eq '9.4.2 beta 2'
+      expect(xcode.version.call).to_not eq '9.4.2 beta 3'
     end
     it 'returns the temporary beta path set by xcversion when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.4.2', '/Applications/Xcode.app')
-      xcode.version.call
       expect(xcode.current_path).to eq '/Applications/Xcode-9.4.2.app'
     end
     it 'returns the name of Xcode 9.3 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.3', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '9.3'
+      expect(xcode.version.call).to eq '9.3'
     end
     it 'returns the name of Xcode 9 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('9.0', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '9'
+      expect(xcode.version.call).to eq '9'
     end
     it 'returns the name of Xcode 8.3.3 when initialized with the semantic version' do
       xcode = MacOS::Xcode.new('8.3.3', '/Applications/Xcode.app')
-      xcode.version.call
-      expect(xcode.version).to eq '8.3.3'
+      expect(xcode.version.call).to eq '8.3.3'
     end
     it 'correctly determines platform compatibility for Xcode 11' do
       xcode = MacOS::Xcode.new('11.0', '/Applications/Xcode.app')
@@ -212,14 +203,12 @@ describe MacOS::Xcode do
 
     it 'ignores the Apple version list and uses the provided version' do
       xcode = MacOS::Xcode.new('0.0', '/Applications/Xcode.app', 'https://www.apple.com')
-      xcode.version.call
-      expect(xcode.version).to eq '0.0'
+      expect(xcode.version.call).to eq '0.0'
     end
 
     it 'ignores the Apple version list and uses the provided version' do
       xcode = MacOS::Xcode.new('2', '/Applications/Xcode.app', 'https://www.apple.com')
-      xcode.version.call
-      expect(xcode.version).to eq '2'
+      expect(xcode.version.call).to eq '2'
     end
   end
 end


### PR DESCRIPTION
# Problem
The Xcode resource currently doesn't indicate what Xcode version it is installing until the install completes.

This behavior makes diagnosing version issues difficult. For example, specifying  "14.0" currently install Xcode 14 Beta 6 and not the Xcode 14 Release Candidate.
> The correct syntax to install the Release Candidate  is "14.Release.Candidate"

# Change
This change adds an additional logging step to specify what Xcode version will be installed
> This change also exposed a bug  in the Xcode resource, where the `version` attribute  is originally a lambda that is then overwritten to be a computed value. Calling `xcode.version.call` twice causes a Chef exception to throw.
>
> This was fixed by not overwriting the value of the `version` attribute.

# Testing
## Example 1
```zsh
* xcode[install Xcode 14.Release.Candidate] action install_xcode[2022-08-17T14:15:20-07:00] INFO: Processing xcode[install Xcode 14.Release.Candidate] action install_xcode (apex_automation::xcode line 1)
       
           * log[Log Xcode information] action write[2022-08-17T14:15:25-07:00] INFO: Processing log[Log Xcode information] action write (/Users/vagrant/kitchen/cache/cookbooks/macos/resources/xcode.rb line 34)
       [2022-08-17T14:15:25-07:00] INFO: Will install Xcode 14 Release Candidate computed from 14.Release.Candidate 
```

## Example 2
```bash
  * xcode[install Xcode 14.0] action install_xcode[2022-08-17T14:05:58-07:00] INFO: Processing xcode[install Xcode 14.0] action install_xcode (apex_automation::xcode line 1)
       
           * log[Log Xcode information] action write[2022-08-17T14:06:01-07:00] INFO: Processing log[Log Xcode information] action write (/Users/vagrant/kitchen/cache/cookbooks/macos/resources/xcode.rb line 34)
       [2022-08-17T14:06:01-07:00] INFO: Will install Xcode 14 beta 6 computed from 14.0
```
