### PR TITLE
Better check for if Xcode is properly installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.0.3] - 2022-11-16
+
+### Fixed
+- Xcode resource verifies that a `xcodebuild` command can be ran when checking to see if Xcode is installed, in addition to verifying that Xcode.app exists.
+
 ## [5.0.2] - 2022-09-08
 
 ### Added

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -50,7 +50,7 @@ module MacOS
     def installed?
       return false if installed_path.nil?
 
-      installed_path.any? && shell_out("DEVELOPER_DIR='#{installed_path}' /usr/bin/xcodebuild -showsdks").exitstatus == 0
+      installed_path.any? && shell_out("DEVELOPER_DIR='#{current_path}' /usr/bin/xcodebuild -showsdks").exitstatus == 0
     end
 
     def compatible_with_platform?(macos_version)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -50,7 +50,7 @@ module MacOS
     def installed?
       return false if installed_path.nil?
 
-      installed_path.any? && shell_out("DEVELOPER_DIR=#{installed_path} /usr/bin/xcodebuild -showsdks").exitstatus == 0
+      installed_path.any? && shell_out("DEVELOPER_DIR='#{installed_path}' /usr/bin/xcodebuild -showsdks").exitstatus == 0
     end
 
     def compatible_with_platform?(macos_version)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -50,7 +50,7 @@ module MacOS
     def installed?
       return false if installed_path.nil?
 
-      installed_path.any? && shell_out('/usr/bin/xcodebuild -showsdks').exitstatus == 0
+      installed_path.any? && shell_out("DEVELOPER_DIR=#{installed_path} /usr/bin/xcodebuild -showsdks").exitstatus == 0
     end
 
     def compatible_with_platform?(macos_version)

--- a/libraries/xcode.rb
+++ b/libraries/xcode.rb
@@ -50,7 +50,7 @@ module MacOS
     def installed?
       return false if installed_path.nil?
 
-      installed_path.any?
+      installed_path.any? && shell_out('/usr/bin/xcodebuild -showsdks').exitstatus == 0
     end
 
     def compatible_with_platform?(macos_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '5.0.2'
+version '5.0.3'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -211,10 +211,13 @@ describe 'xcode' do
   end
 
   context 'with requested Xcode installed at a different path' do
+    let(:shellout) { double(stdout: 'Some output', stderr: '', exitstatus: 0) }
+
     before(:each) do
       allow(MacOS::XCVersion).to receive(:installed_xcodes)
         .and_return([{ '10.0' => '/Applications/Some_Weird_Path.app' }])
       stub_command('test -L /Applications/Xcode.app').and_return(false)
+      allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out).and_return(shellout)
     end
 
     recipe do


### PR DESCRIPTION
## Problem
If Xcode install fails after the download but before Xcode is completely installed, subsequent Chef runs won't properly reinstall Xcode.

## Change  
This change adds an additional check to the `installed?` definition, ensuring that `/usr/bin/xcodebuild -showsdks` returns an exit code of 0 to consider Xcode properly installed.