### PR TITLE
Explicitly use the Apple hypervisor framework for Kitchen CI suites

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -2,6 +2,8 @@
 driver:
   name: vagrant
   provider: parallels
+  customize:
+    hypervisor-type: apple
 
 provisioner:
   product_name: chef


### PR DESCRIPTION
Ensure that we're explicitly using the Apple hypervisor framework for Kitchen CI suites. This resolves an issue where the Vagrant Parallels provider may not select the correct hypervisor for the build agents.