### PR TITLE
Fix autologin for 12.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.0.4] - 2023-01-31
+
+### Added
+- Added key `LastPrivacyBundleVersion` to `macos_user` resource to allow for dimissing more Welcome screens in macOS 12.6.3
+
 ## [5.0.3] - 2022-11-16
 
 ### Fixed

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '5.0.3'
+version '5.0.4'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -44,6 +44,7 @@ action_class do
       'LastSeenCloudProductVersion' => node['platform_version'],
       'LastPreLoginTasksPerformedVersion' => node['platform_version'],
       'LastPreLoginTasksPerformedBuild' => node['platform_build'],
+      'LastPrivacyBundleVersion' => '2',
       'LastSeenBuddyBuildVersion' => node['platform_build'],
       'LastSeenSiriProductVersion' => node['platform_version'],
     }


### PR DESCRIPTION
## Describe the Pull Request  
Adds `LastPrivacyBundleVersion` to com.apple.SetupAssistant.plist. This value was present after updating to 12.6.3.

## Justification  
This prevented the user from auto logging in and caused the Privacy buddy window to pop up.