### PR TITLE
Be able to install command line tools if machine previously installed them but were wiped from a major OS upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.0.5] - 2023-06-20
+
+### Fixed
+- Updated `command_line_tools` so that machines are able to install previously installed command line tools if they were wiped from a major macOS upgrade.
+
 ## [5.0.4] - 2023-01-31
 
 ### Added

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -68,7 +68,6 @@ module MacOS
     end
 
     def softwareupdate_list
-      enable_install_on_demand
       shell_out(['softwareupdate', '--list']).stdout.lines
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '5.0.4'
+version '5.0.5'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/command_line_tools.rb
+++ b/resources/command_line_tools.rb
@@ -9,6 +9,8 @@ property :compile_time, [true, false],
 action :install do
   command_line_tools = CommandLineTools.new
 
+  command_line_tools.enable_install_on_demand
+
   execute "install #{command_line_tools.version}" do
     command ['softwareupdate', '--install', command_line_tools.version]
     not_if { ::File.exist?('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib') }
@@ -23,6 +25,8 @@ end
 
 action :upgrade do
   command_line_tools = CommandLineTools.new
+
+  command_line_tools.enable_install_on_demand
 
   execute "upgrade #{command_line_tools.version}" do
     command ['softwareupdate', '--install', command_line_tools.latest_from_catalog]


### PR DESCRIPTION
After a major macOS upgrade, command line tools are usually removed. However, the /Library/Receipts/InstallHistory.plist file still keeps history of the command line tools that were installed, so the machine thinks that they are installed.

This causes the machine to go through these steps:
1. '/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib' does not exist (because of the os upgrade), so it executes the install block
2. The version it tries to install is the latest installed command line tools according to InstallHistory.plist.
3. We don't try to scan the softwareupdate catalog because the InstallHistory.plist has previously recorded CLT installs.
4. Since we don't scan the catalog, we never create the sentinel file.
5. Because there's no sentinel file, we can't install the CLT that was on the machine prior to macOS upgrade.

This problem is easily fixed if we touch the sentinel file prior to install. This change slightly refactors where we touch the sentinel file.