### PR TITLE
CLT: Fix permissions error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.0.6] - 2023-06-23
+
+### Fixed
+- Fixed permissions issue with the `macos::command_line_tools` resource. 
+
 ## [5.0.5] - 2023-06-20
 
 ### Fixed

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -43,7 +43,7 @@ platforms:
 - name: monterey-chef17
   driver:
     box: microsoft/macos-monterey
-    box_version: 12.3.1
+    box_version: 12.6.3
   provisioner:
     product_version: 17
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 14.0'
-version '5.0.5'
+version '5.0.6'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/command_line_tools.rb
+++ b/resources/command_line_tools.rb
@@ -20,7 +20,7 @@ action :install do
     live_stream true
   end
 
-  file 'sentinel to request on-demand install' do
+  file 'delete sentinel file' do
     path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
     action :delete
   end
@@ -40,7 +40,7 @@ action :upgrade do
     live_stream true
   end
 
-  file 'sentinel to request on-demand install' do
+  file 'delete sentinel file' do
     path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
     action :delete
   end

--- a/resources/command_line_tools.rb
+++ b/resources/command_line_tools.rb
@@ -9,7 +9,10 @@ property :compile_time, [true, false],
 action :install do
   command_line_tools = CommandLineTools.new
 
-  command_line_tools.enable_install_on_demand
+  file 'create sentinel file' do
+    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+    group 'wheel'
+  end
 
   execute "install #{command_line_tools.version}" do
     command ['softwareupdate', '--install', command_line_tools.version]
@@ -26,7 +29,10 @@ end
 action :upgrade do
   command_line_tools = CommandLineTools.new
 
-  command_line_tools.enable_install_on_demand
+  file 'create sentinel file' do
+    path '/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress'
+    group 'wheel'
+  end
 
   execute "upgrade #{command_line_tools.version}" do
     command ['softwareupdate', '--install', command_line_tools.latest_from_catalog]

--- a/spec/unit/resources/command_line_tools_spec.rb
+++ b/spec/unit/resources/command_line_tools_spec.rb
@@ -21,7 +21,9 @@ describe 'command_line_tools' do
       end
     end
 
+    it { is_expected.to create_file('create sentinel file') }
     it { is_expected.to run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
+    it { is_expected.to delete_file('delete sentinel file') }
   end
 
   context 'with libxcrun present' do
@@ -35,7 +37,9 @@ describe 'command_line_tools' do
       end
     end
 
+    it { is_expected.to create_file('create sentinel file') }
     it { is_expected.to_not run_execute('install Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.0') }
+    it { is_expected.to delete_file('delete sentinel file') }
   end
 end
 
@@ -61,9 +65,11 @@ describe 'command_line_tools' do
       end
     end
 
+    it { is_expected.to create_file('create sentinel file') }
     it {
       is_expected.to run_execute('upgrade Command Line Tools for Xcode-11.0')
         .with(command: ['softwareupdate', '--install', 'Command Line Tools for Xcode-22.0'])
     }
+    it { is_expected.to delete_file('delete sentinel file') }
   end
 end


### PR DESCRIPTION
## Describe the Pull Request  
- Use the core `file` resource to create the sentinel file instead of using `FileUtils`.
-  Update UTs for the CLT resource

## Justification  
- Fixes permissions error when trying to create the sentinel file with `FileUtils`
   ```
     Errno::EPERM:
       command_line_tools[horse] (macos::_test line 33) had an error: Errno::EPERM: Operation not permitted @ apply2files - /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
   ```
