### PR TITLE
split out pre-Haswell Kitchen VM jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
 - template: chefspec-cookstyle.yml@templates
 - template: test-kitchen.yml@templates
   parameters:
-    jobName: "macos>=13"
+    jobName: "haswell"
     kitchenFile: kitchen.yml
     venturaPlus: true
     platforms:
@@ -71,7 +71,7 @@ jobs:
     suites: ${{ parameters.kitchenSuites }}
 - template: test-kitchen.yml@templates
   parameters:
-    jobName: "macos<=12"
+    jobName: "vintage"
     platforms:
     - big-sur-x86
     - monterey-x86

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,23 +42,38 @@ resources:
     type: git
     name: chef-pipelines-templates
 
+parameters:
+  - name: kitchenSuites
+    displayName: Kitchen Suites
+    type: object
+    default:
+      - default
+      - software-updates
+      - spotlight
+      # - xcode-from-apple
+      # - xcode-from-url
+      - command-line-tools
+      - certificate
+      - users
+      - keychain
+      - remote-access
+
 jobs:
 - template: chefspec-cookstyle.yml@templates
 - template: test-kitchen.yml@templates
   parameters:
+    jobName: "macos>=13"
+    kitchenFile: kitchen.yml
+    venturaPlus: true
+    platforms:
+      - ventura-x86
+    # - ventura-arm
+    suites: ${{ parameters.kitchenSuites }}
+- template: test-kitchen.yml@templates
+  parameters:
+    jobName: "macos<=12"
     platforms:
     - big-sur-x86
     - monterey-x86
-    # - ventura-arm
-    suites:
-    - default
-    - software-updates
-    - spotlight
-    # - xcode-from-apple
-    # - xcode-from-url
-    - command-line-tools
-    - certificate
-    - users
-    - keychain
-    - remote-access
+    suites: ${{ parameters.kitchenSuites }}
     kitchenFile: kitchen.yml

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -33,7 +33,7 @@ platforms:
 - name: ventura-x86
   driver:
     box: microsoft/macos-ventura
-    box_version: 13.4
+    box_version: 13.4.1
 
 - name: ventura-arm
   driver:


### PR DESCRIPTION
## Describe the Pull Request  
This PR enables Ventura x86 Kitchen CI runs to run on Haswell hardware, and for older runs to be hosted by pre-Haswell hosts.