### PR TITLE
update macos_user to handle a nil password

### DIFF
--- a/libraries/macos_user.rb
+++ b/libraries/macos_user.rb
@@ -3,7 +3,7 @@ module MacOS
     def kcpassword_hash(password)
       bits = magic_bits
       obfuscated = []
-      padded(password).each do |char|
+      padded(password.to_s).each do |char|
         obfuscated.push(bits[0] ^ char)
         bits.rotate!
       end

--- a/libraries/macos_user.rb
+++ b/libraries/macos_user.rb
@@ -1,7 +1,11 @@
 module MacOS
   module MacOSUserHelpers
     def kcpassword_hash(password)
-      bits = magic_bits
+      bits = if password.nil?
+               nil_magic_bits
+             else
+               magic_bits
+             end
       obfuscated = []
       padded(password.to_s).each do |char|
         obfuscated.push(bits[0] ^ char)
@@ -14,6 +18,10 @@ module MacOS
 
     def magic_bits
       [125, 137, 82, 35, 210, 188, 221, 234, 163, 185, 31]
+    end
+
+    def nil_magic_bits
+      [125, 238, 148, 74, 161, 237, 34, 160, 79, 144, 210, 199]
     end
 
     def magic_len

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -132,7 +132,7 @@ action :create do
       command 'pwpolicy clearaccountpolicies'
       not_if do
         Plist.parse_xml(shell_out('pwpolicy getaccountpolicies').stdout)['policyCategoryPasswordContent']
-             .map { |policy| policy['policyContent'] }.include?("policyAttributePassword matches '.{0,}'")
+             .map { |policy| policy['policyContent'] }.include?("policyAttributePassword matches '.{0,}?'")
       end
       notifies :run, 'execute[enable passwords with zero length]', :immediately
     end

--- a/spec/unit/libraries/macos_user_spec.rb
+++ b/spec/unit/libraries/macos_user_spec.rb
@@ -14,4 +14,10 @@ describe MacOS::MacOSUserHelpers, '#kcpassword_hash' do
       expect(kcpassword_hash('correct-horse-battery-staple')).to eq "\x1E\xE6 Q\xB7\xDF\xA9\xC7\xCB\xD6m\x0E\xEC\x7FA\xB3\xC8\xA9\x8F\xD1\xC02\x0E\xFD3S\xBE\xD9\xDD\xEA\xA3\xB9\x1F".force_encoding('ASCII-8BIT')
     end
   end
+
+  context 'When calling the obfuscate method on a password that is nil' do
+    it 'the password hash value is that of an empty string' do
+      expect(kcpassword_hash(nil)).to eq "}\x89R#\xD2\xBC\xDD\xEA\xA3\xB9\x1F".force_encoding('ASCII-8BIT')
+    end
+  end
 end

--- a/spec/unit/libraries/macos_user_spec.rb
+++ b/spec/unit/libraries/macos_user_spec.rb
@@ -17,7 +17,7 @@ describe MacOS::MacOSUserHelpers, '#kcpassword_hash' do
 
   context 'When calling the obfuscate method on a password that is nil' do
     it 'the password hash value is that of an empty string' do
-      expect(kcpassword_hash(nil)).to eq "}\x89R#\xD2\xBC\xDD\xEA\xA3\xB9\x1F".force_encoding('ASCII-8BIT')
+      expect(kcpassword_hash(nil)).to eq "}\xEE\x94J\xA1\xED\"\xA0O\x90\xD2".force_encoding('ASCII-8BIT')
     end
   end
 end

--- a/spec/unit/resources/macos_user_spec.rb
+++ b/spec/unit/resources/macos_user_spec.rb
@@ -56,6 +56,31 @@ describe 'macos_user with a weak password on machine with a password policy' do
   end
 end
 
+describe 'macos_user with no password on machine without a password policy' do
+  step_into :macos_user
+
+  platform 'mac_os_x', '11'
+
+  before do
+    stubs_for_provider('macos_user[create user with no password]') do |provider|
+      allow(provider).to receive_shell_out('/usr/sbin/sysadminctl', '', '-addUser', 'cloudtest', '', '', '',
+                                           stderr: 'creating user record…', exitstatus: 0)
+      allow(provider).to receive_shell_out('/usr/sbin/sysadminctl', '-secureTokenStatus', 'cloudtest',
+                                           stderr: 'Secure token is DISABLED for user cloudtest', exitstatus: 0)
+    end
+  end
+
+  recipe do
+    macos_user 'create user with no password' do
+      username 'cloudtest'
+      secure_token false
+      autologin true
+    end
+  end
+
+  it { is_expected.to create_macos_user('create user with no password') }
+end
+
 describe 'macos_user attempting to delete the last secure token user' do
   step_into :macos_user
 

--- a/test/cookbooks/macos_test/recipes/users.rb
+++ b/test/cookbooks/macos_test/recipes/users.rb
@@ -53,3 +53,7 @@ macos_user "remove existing user's secure token" do
   secure_token false
   existing_token_auth({ username: 'vagrant', password: 'vagrant' })
 end
+
+macos_user 'create user with no password' do
+  username 'hunter2'
+end


### PR DESCRIPTION
This PR:

- Enables the creation of a local user without a password by handling a nil password property. 
- Updates the autologin generator helper to correct pack what macOS expects for this scenario, which is an empty string.