### PR TITLE
idempotence fix for macos_user SecureToken

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 16.0'
-version '6.0.0'
+version '6.0.1'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -123,7 +123,7 @@ action_class do
 end
 
 action :create do
-  if new_resource.secure_token && !property_is_set?(:existing_token_auth)
+  if new_resource.secure_token && !secure_token_enabled? && !property_is_set?(:existing_token_auth)
     raise "An existing_token_auth hash must be provided if you want a secure token for #{new_resource.username}!" unless logged_in?('_mbsetupuser') || logged_in?('vagrant')
   end
 


### PR DESCRIPTION
Fixes an issue where SecureToken user resource calls were not idempotent if not called with an existing token Hash.