### PR TITLE
Update 'MiniBuddyLaunchReason' to be an int

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 16.0'
-version '6.0.2'
+version '6.0.3'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -49,7 +49,7 @@ action_class do
       'LastSeenBuddyBuildVersion' => node['platform_build'],
       'LastSeenDiagnosticsProductVersion' => node['platform_version'],
       'LastSeenSiriProductVersion' => node['platform_version'],
-      'MiniBuddyLaunchReason' => '0',
+      'MiniBuddyLaunchReason' => 0,
     }
   end
 


### PR DESCRIPTION
I am seeing `macos_user` update this field each time from int to string. On reboot it changes back to int in the plist file so this resource is never unchanged. That is causing some issues with notifications to restart that I have set up.