### PR TITLE
Fix autologin for 15.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 =======
 
+## [6.0.6] - 2025-04-18
+
+### Added
+
+- Added keys to `macos_user` resource to allow for dimissing more Welcome screens in macOS 15.4.1.
+  - `InitialAccountSetupDate`
+  - `InitialSetupBuildVersion`
+  - `InitialSetupProductVersion`
+  - `LastSeenIntelligenceProductVersion`
+  - `selectedFDEEscrowType`
+
 ## [6.0.0] - 2024-04-04
 
 ### Removed

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 16.0'
-version '6.0.5'
+version '6.0.6'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/macos_user.rb
+++ b/resources/macos_user.rb
@@ -42,14 +42,19 @@ action_class do
       'DidSeeAppearanceSetup' => true,
       'DidSeeScreenTime' => true,
       'DidSeeiCloudLoginForStorageServices' => true,
+      'InitialAccountSetupDate' => ::Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+      'InitialSetupBuildVersion' => node['platform_build'],
+      'InitialSetupProductVersion' => node['platform_version'],
       'LastSeenCloudProductVersion' => node['platform_version'],
       'LastPreLoginTasksPerformedVersion' => node['platform_version'],
       'LastPreLoginTasksPerformedBuild' => node['platform_build'],
       'LastPrivacyBundleVersion' => '2',
+      'LastSeenIntelligenceProductVersion' => node['platform_version'],
       'LastSeenBuddyBuildVersion' => node['platform_build'],
       'LastSeenDiagnosticsProductVersion' => node['platform_version'],
       'LastSeenSiriProductVersion' => node['platform_version'],
       'MiniBuddyLaunchReason' => 0,
+      'selectedFDEEscrowType' => 'DeclinedFDE',
     }
   end
 


### PR DESCRIPTION
## Describe the Pull Request  
This PR fixes autologin issues introduced with updates to 15.4.1. The missing properties are added to the Setup Assistant plist to bypass manual clicks.

## Justification  
Upgrading from 14 to 15 blocks automatic login with a new prompt about Apple Intelligence.