### PR TITLE
Sets HOME in defaults to fix broken behavior

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 16.0'
-version '6.0.7'
+version '6.0.8'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/defaults.rb
+++ b/resources/defaults.rb
@@ -41,7 +41,7 @@ action :run do
     execute "#{setting} to #{value}" do
       command "/usr/bin/defaults #{new_resource.option} #{Shellwords.shellescape(new_resource.domain)} #{Shellwords.shellescape(setting)} #{value}"
       user new_resource.user
-      environment ({ 'HOME' => Etc.getpwnam(new_resource.user).dir })
+      environment({ 'HOME' => MacOS::UserPath.home(new_resource.user) })
     end
   end
 end

--- a/resources/defaults.rb
+++ b/resources/defaults.rb
@@ -41,7 +41,7 @@ action :run do
     execute "#{setting} to #{value}" do
       command "/usr/bin/defaults #{new_resource.option} #{Shellwords.shellescape(new_resource.domain)} #{Shellwords.shellescape(setting)} #{value}"
       user new_resource.user
-      environment ({ 'HOME' => "/Users/#{new_resource.user}" })
+      environment ({ 'HOME' => Etc.getpwnam(new_resource.user).dir })
     end
   end
 end

--- a/resources/defaults.rb
+++ b/resources/defaults.rb
@@ -41,6 +41,7 @@ action :run do
     execute "#{setting} to #{value}" do
       command "/usr/bin/defaults #{new_resource.option} #{Shellwords.shellescape(new_resource.domain)} #{Shellwords.shellescape(setting)} #{value}"
       user new_resource.user
+      environment ({ 'HOME' => "/Users/#{new_resource.user}" })
     end
   end
 end

--- a/resources/defaults.rb
+++ b/resources/defaults.rb
@@ -7,7 +7,7 @@ property :option, String, default: 'write'
 property :read_only, [true, false], default: false
 property :settings, Hash
 property :system, [true, false]
-property :user, String
+property :user, String, required: true
 
 action_class do
   def convert_to_string_from_data_type(value)


### PR DESCRIPTION
Sets HOME to the user directory otherwise defaults read/write has strange behavior.

Haven't figured out what its modifying without this change, but its definitely not the user's defaults nor is it root's. It seems to be some strange in-between that doesn't end up doing anything useful.

Let me know if this is the wrong way to set the HOME var!
