### PR TITLE
Fix Command Line Tools issue on Tahoe + fix publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,3 +92,10 @@ extends:
           platforms:
             - monterey-x86
           suites: ${{ parameters.kitchenSuites }}
+    - stage: supermarket
+      dependsOn: cookbook
+      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      jobs:
+        - template: supermarket.yml@templates
+          parameters:
+            cookbookName: 'macos'

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -60,7 +60,7 @@ module MacOS
     end
 
     def xcode_version(product)
-      product.match(/Xcode-(?<version>\d+\.\d+)/)['version']
+      product.match(/Xcode.{0,20}-(?<version>\d+\.\d+)/)['version']
     end
 
     def macos_version

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 16.0'
-version '6.0.8'
+version '6.0.9'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'


### PR DESCRIPTION
---

name: Fix Command Line Tools issue on Tahoe + fix publishing
about: Fixes a Tahoe update issue with Command Line Tools and points to the new supermarket.yml file for publishing the cookbook.

---

## Describe the Pull Request  

Fixes a Tahoe update issue with Command Line Tools and points to the new supermarket.yml file for publishing the cookbook. The change to publishing is needed because of new security requirements as part of 1ES pipeline templates.