### PR TITLE
Fix regex to match Xcode 26 version format

### DIFF
--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -60,7 +60,7 @@ module MacOS
     end
 
     def xcode_version(product)
-      product.match(/Xcode-(?<version>\d+\.\d+)/)['version']
+      product.match(/Xcode(-| )(?<version>\d+\.\d+)/)['version']
     end
 
     def macos_version


### PR DESCRIPTION
Xcode 26 changed the version string format in softwareupdate --list ex. "* Label: Command Line Tools for Xcode 26.0-26.0" vs "* Label: Command Line Tools for Xcode-16.4"

Currently hardcoding in a possible space rather than - separator, but will likely need to revisit this once the next version of Xcode comes out and we know what Xcode 26 versions will actually look like.