### PR TITLE
Fix macOS version extraction regex

### DIFF
--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -64,7 +64,7 @@ module MacOS
     end
 
     def macos_version
-      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/[12][\d]\.\d+/]
+      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/[\d][\d]\.\d+/]
     end
 
     def softwareupdate_list

--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -64,7 +64,7 @@ module MacOS
     end
 
     def macos_version
-      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/1[\d]\.\d+/]
+      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/[12][\d]\.\d+/]
     end
 
     def softwareupdate_list

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 16.0'
-version '6.0.9'
+version '6.0.10'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'


### PR DESCRIPTION
macOS 26 broke our version regex, changing it to accept either 1 or 2 as the first digit in the version (we'd previously hardcoded 1 as the first digit)