### PR TITLE
Update regex for extracting Xcode version

### DIFF
--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -60,7 +60,7 @@ module MacOS
     end
 
     def xcode_version(product)
-      product.match(/Xcode.{0,20}-(?<version>\d+\.\d+)/)['version']
+      product.match(/Xcode.{0,20}-(?<version>\d+\.\d+(?:\.\d+)?)/)['version']
     end
 
     def macos_version


### PR DESCRIPTION
The new Xcode version format has changed allowing for a patch version number, which we currently do not support in our version number regex. This lets us parse that new patch version (as well as allowing for potentially multiple digits in that patch version.)