### PR TITLE
Fix regex for macOS version extraction

### DIFF
--- a/libraries/command_line_tools.rb
+++ b/libraries/command_line_tools.rb
@@ -64,7 +64,7 @@ module MacOS
     end
 
     def macos_version
-      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/[\d][\d]\.\d+/]
+      shell_out(['/usr/bin/sw_vers', '-productVersion']).stdout.chomp[/[\d][\d]\.\d+(?:\.\d+)?/]
     end
 
     def softwareupdate_list


### PR DESCRIPTION
Similar to previous recent fixes, the new patch version of Tahoe broke the `macos_version` regex pattern. This commit fixes that, however I did notice that it would (correctly) output 26.0.1 which would _not_ match the current Command Line Tools version of 26.0-26.0, and so would return no suggested Command Line Tool version in the `platform_specific` function (incorrectly?).

So might need to also address that logic in this PR before completion, but will defer to reviewers.