### PR TITLE
Install specific version of signet to mitigate Ruby 3.2+ requirement

### DIFF
--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -35,6 +35,7 @@ action :install_gem do
   execute 'install xcode gem' do
     cwd '/tmp'
     command <<~BASH
+          #{gem_bin} install --no-document signet --force --version 0.21.0 && \
           #{gem_bin} install --no-document fastlane --force --version 2.229.0 && \
           #{gem_bin} install --no-document xcode-install --force
           BASH


### PR DESCRIPTION
---
name: Install specific version of signet to mitigate Ruby 3.2+ requirement
---

The latest release of signet requires Ruby 3.2+ which both Chef and CINC 18.x do not support. We can undo this when we eventually update to 19.x in the future.