### PR TITLE
Pin google-cloud-core to 1.8 

### DIFF
--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -36,6 +36,7 @@ action :install_gem do
     cwd '/tmp'
     command <<~BASH
           #{gem_bin} install --no-document signet --force --version 0.21.0 && \
+          #{gem_bin} install --no-document google-cloud-core --force --version 1.8.0 && \
           #{gem_bin} install --no-document fastlane --force --version 2.229.0 && \
           #{gem_bin} install --no-document xcode-install --force
           BASH


### PR DESCRIPTION
Pin google-cloud-core to 1.8 because 1.9 requires Ruby 3.2. https://github.com/googleapis/google-cloud-ruby/commit/1414d99377f537107ffe4c84f8c23f99f1b743ff