### PR TITLE
Pin google-cloud-errors to 1.6.0 for Xcode installs

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@microsoft.com'
 license 'MIT'
 description 'Resources for configuring and provisioning macOS'
 chef_version '>= 16.0'
-version '6.0.11'
+version '6.0.12'
 
 source_url 'https://github.com/Microsoft/macos-cookbook'
 issues_url 'https://github.com/Microsoft/macos-cookbook/issues'

--- a/resources/xcode.rb
+++ b/resources/xcode.rb
@@ -35,6 +35,7 @@ action :install_gem do
   execute 'install xcode gem' do
     cwd '/tmp'
     command <<~BASH
+          #{gem_bin} install --no-document google-cloud-errors --force --version 1.6.0 && \
           #{gem_bin} install --no-document signet --force --version 0.21.0 && \
           #{gem_bin} install --no-document google-cloud-core --force --version 1.8.0 && \
           #{gem_bin} install --no-document fastlane --force --version 2.229.0 && \

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -253,3 +253,28 @@ describe 'xcode' do
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 end
+
+describe 'xcode install_gem' do
+  step_into :xcode
+  platform 'mac_os_x'
+
+  # Fresh host (no xcversion yet): the install chain runs and pins google-cloud-errors 1.6.0
+  # first -- before google-cloud-core 1.8.0 -- so the incompatible 1.7.0 is never resolved.
+  context 'on a fresh host with no xcversion installed' do
+    before(:each) do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(end_with('xcversion')).and_return(false)
+    end
+
+    recipe do
+      xcode '26' do
+        action :install_gem
+      end
+    end
+
+    it {
+      is_expected.to run_execute('install xcode gem')
+        .with(command: /google-cloud-errors --force --version 1\.6\.0[\s\S]*google-cloud-core --force --version 1\.8\.0/)
+    }
+  end
+end

--- a/spec/unit/resources/xcode_spec.rb
+++ b/spec/unit/resources/xcode_spec.rb
@@ -253,28 +253,3 @@ describe 'xcode' do
     it { is_expected.to run_execute('switch active Xcode to /Applications/Xcode.app') }
   end
 end
-
-describe 'xcode install_gem' do
-  step_into :xcode
-  platform 'mac_os_x'
-
-  # Fresh host (no xcversion yet): the install chain runs and pins google-cloud-errors 1.6.0
-  # first -- before google-cloud-core 1.8.0 -- so the incompatible 1.7.0 is never resolved.
-  context 'on a fresh host with no xcversion installed' do
-    before(:each) do
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with(end_with('xcversion')).and_return(false)
-    end
-
-    recipe do
-      xcode '26' do
-        action :install_gem
-      end
-    end
-
-    it {
-      is_expected.to run_execute('install xcode gem')
-        .with(command: /google-cloud-errors --force --version 1\.6\.0[\s\S]*google-cloud-core --force --version 1\.8\.0/)
-    }
-  end
-end


### PR DESCRIPTION
## Summary

- pin `google-cloud-errors` to `1.6.0` before `google-cloud-core` in the Xcode gem install chain
- prevent fresh Chef 18.5 / Ruby 3.1 hosts from resolving incompatible `google-cloud-errors 1.7.0`
- add a ChefSpec ordering contract

## Incident

`google-cloud-errors 1.7.0` was published with Ruby >= 3.2 and caused `xcversion install` to fail under Chef 18.5 embedded Ruby 3.1, leaving ACES Agents stuck in `Bootstrapped`. After this reaches production, Ops will wipe affected hosts so they rerun the corrected fresh-install path.

## Validation

- `chef exec rspec spec/unit/resources/xcode_spec.rb` — 27 examples, 0 failures
- `chef exec rspec spec/` — 191 examples, 0 failures
- Cookstyle introduces no new offenses versus `master`
